### PR TITLE
Clean up code around OAuth2.0

### DIFF
--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,0 +1,1 @@
+console.log('hi');

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,1 +1,52 @@
-console.log('hi');
+function onSignIn(googleUser) {
+
+  // Useful data for client-side scripts:
+  var profile = googleUser.getBasicProfile();
+  console.log("ID: " + profile.getId()); // Don't send this directly to your server!
+  console.log('Full Name: ' + profile.getName());
+  console.log("Email: " + profile.getEmail());
+
+  // The ID token you need to pass to your backend:
+  var id_token = googleUser.getAuthResponse().id_token;
+  console.log("ID Token: " + id_token);
+}
+
+//This function isn't actually being called at the moment
+function signinCallback(authResult) {
+  if (authResult['access_token']) {
+
+    // The user is signed in
+    var loc = 'index.jsp?GoogleAuthToken=' + authResult['access_token'];
+    window.location.href = loc;
+  } else if (authResult['error']) {
+
+    // There was an error, which means the user is not signed in.
+    console.error(authResult);
+    return false;
+  }
+}
+
+function signOut(event) {
+
+  //don't immediately redirect the user
+  event.preventDefault();
+
+  //send sign-out request to Google
+  var auth2 = gapi.auth2.getAuthInstance();
+  auth2.signOut()
+    .then(function () {
+      console.log('User signed out.');
+
+      //redirect user after confirmation of sign-out received
+      window.location.href='/';
+    }
+  );
+}
+
+// Code in this anonymous function is immediately invoked once this script loads:
+(function() {
+
+  //when the sign-out link is clicked, the signOut function is executed
+  var signOutLink = document.getElementById('signOut');
+  signOutLink.addEventListener('click', signOut);
+}());

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -6,6 +6,10 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css" integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous">
     <link rel="stylesheet" href="/static/css/custom.css">
+
+    {% block headContent %}
+
+    {% endblock %}
   </head>
   <body>
     
@@ -15,5 +19,9 @@
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+
+    {% block scriptContent %}
+    
+    {% endblock %}
   </body>
 </html>

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -1,11 +1,12 @@
 {% extends "layouts/base.html" %}
 
+{% block headContent %}
+  <meta name="google-signin-scope" content="profile email">
+  <meta name="google-signin-client_id" content="649609603099-g73psa76kgviat4mdh2ctt1pk8he11bb.apps.googleusercontent.com">
+  <script src="https://apis.google.com/js/platform.js" async defer></script>
+{% endblock %}
+
 {% block content %}
-<head>
-    <meta name="google-signin-scope" content="profile email">
-    <meta name="google-signin-client_id" content="649609603099-g73psa76kgviat4mdh2ctt1pk8he11bb.apps.googleusercontent.com">
-    <script src="https://apis.google.com/js/platform.js" async defer></script>
-</head>
 <body>
   <div class="container-outer">
     <div class="container">
@@ -56,3 +57,7 @@
 
 </body>
 {% endblock %} 
+
+{% block scriptContent %}
+  <script src="/static/js/auth.js"></script>
+{% endblock %}

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -7,53 +7,23 @@
 {% endblock %}
 
 {% block content %}
-<body>
-  <div class="container-outer">
-    <div class="container">
-      <div class="row">
-        <div class="col-xs-12">
-          <a class="pull-right" href="/">Return to homepage</a>
-        </div>
+
+<div class="container-outer">
+  <div class="container">
+    <div class="row">
+      <div class="col-xs-12">
+        <a class="pull-right" href="/">Return to homepage</a>
       </div>
-      <div class="row">
-        <h2>Organization Sign-Up</h2>
-      </div>
-      <div class="g-signin2" data-onsuccess="onSignIn" redirect-uri="igninCallback" data-theme="dark"></div>
-      <script>
-        function onSignIn(googleUser) {
-          // Useful data for client-side scripts:
-          var profile = googleUser.getBasicProfile();
-          console.log("ID: " + profile.getId()); // Don't send this directly to your server!
-          console.log('Full Name: ' + profile.getName());
-          console.log("Email: " + profile.getEmail());
-  
-          // The ID token you need to pass to your backend:
-          var id_token = googleUser.getAuthResponse().id_token;
-          console.log("ID Token: " + id_token)
-        };
+    </div>
+    <div class="row">
+      <h2>Organization Sign-Up</h2>
+    </div>
 
-          function signinCallback(authResult) {
-            if (authResult['access_token']) {
-              // The user is signed in
-              var loc = 'index.jsp?GoogleAuthToken=' + authResult['access_token'];
-              window.location.href = loc;
-              } else if (authResult['error']) {
-              // There was an error, which means the user is not signed in.
-              return false;
-              }
-          }
-        </script>
-
-
-        <a href="/" onclick="signOut();">Sign out</a>
-        <script>
-        function signOut() {
-          var auth2 = gapi.auth2.getAuthInstance();
-          auth2.signOut().then(function () {
-            console.log('User signed out.');
-          });
-        }
-      </script>
+    <!-- Google Sign-In button, controlled from Google's platform.js script -->
+    <div class="g-signin2" data-onsuccess="onSignIn" redirect-uri="signinCallback" data-theme="dark"></div>
+    <a href="/" id="signOut">Sign out</a>
+  </div>
+</div>
 
 </body>
 {% endblock %} 


### PR DESCRIPTION
- Adds blocks in the base.html layout file for additional content for `<head>`, and for scripts that should appear at bottom of `<body>`
- Moves all of the JavaScript on the sign-in page from `<script>` tags to a dedicated file (in `static/js/auth.js`)
- Adds an event listener to the sign-out button
- On user sign out, waits for confirmation from Google before redirecting user to homepage.