### PR TITLE
Display errors in browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Voluntr
-## Current Version: 0.13.1
+## Current Version: 0.14.0
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>
 
 # Table of Contents

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -41,4 +41,6 @@ body {
   position: relative;
 }
 
-
+.alert-container .alert {
+  margin: 10px;
+}

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,11 +1,25 @@
-// TODO: display meaningful feedback for errors outside of the console
-function handleError(err) {
-  console.log("There's been an error: ", err);
+// display error messages as alert elements in browser
+function displayError(message) {
+
+  //allow for direct input of error objects:
+  if (message instanceof Error) {
+    message = message.message;
+  }
+
+  //select a container for the alert
+  var alertContainer = document.querySelector(".alert-container");
+
+  //build a new DOM element
+  var alert = document.createElement("div");
+  alert.className = `alert alert-danger alert-dismissible fade in`;
+  alert.innerHTML = `<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Error: </strong>${message}`;
+
+  //append the new DOM element to the container
+  alertContainer.appendChild(alert);
 }
 
 // TODO: Finish this function and call it on successful sign-in.
 function onSignIn(googleUser) {
-
   // Build an object with the data we wish to send to server
   var profile = googleUser.getBasicProfile();
   var id_token = googleUser.getAuthResponse().id_token;
@@ -13,45 +27,44 @@ function onSignIn(googleUser) {
     contactName: profile.getName(),
     email: profile.getEmail(),
     idtoken: id_token
-  }
+  };
 
   // build a fetch request to POST user's Google data to server for verification:
   var requestOptions = {
-    method: 'POST',
+    method: "POST",
     body: JSON.stringify(userDataToSend)
   };
 
-  requestOptions.headers = new Headers;
-  requestOptions.headers.append('Content-Type', 'application/json');
+  requestOptions.headers = new Headers();
+  requestOptions.headers.append("Content-Type", "application/json");
 
   // TODO: set this:
-  var authUrl = '';
+  var authUrl = "";
 
   // Send the request, and respond to both successful and failure outcomes:
   fetch(authUrl, requestOptions)
     .then(function(response) {
       if (response.status >= 300) {
-        handleError(response);
+        displayError(response);
       } else {
-        response.json()
+        response
+          .json()
           .then(function(responseData) {
-
             // TODO: Create an actual response here. Should request more data from new users, and redirect to logged-in view for returning users.
-            console.log('Success! Server responded with: ', responseData);
+            console.log("Success! Server responded with: ", responseData);
           })
-          .catch(handleError);
+          .catch(displayError);
       }
     })
-    .catch(handleError);
+    .catch(displayError);
 }
 
 // TODO: remove this once the above function works
 function onSignInTemp(googleUser) {
-
   // Useful data for client-side scripts:
   var profile = googleUser.getBasicProfile();
   console.log("ID: " + profile.getId()); // Don't send this directly to your server!
-  console.log('Full Name: ' + profile.getName());
+  console.log("Full Name: " + profile.getName());
   console.log("Email: " + profile.getEmail());
 
   // The ID token you need to pass to your backend:
@@ -61,13 +74,11 @@ function onSignInTemp(googleUser) {
 
 //TODO: This function isn't actually being called at the moment. Do we need it?
 function signinCallback(authResult) {
-  if (authResult['access_token']) {
-
+  if (authResult["access_token"]) {
     // The user is signed in
-    var loc = 'index.jsp?GoogleAuthToken=' + authResult['access_token'];
+    var loc = "index.jsp?GoogleAuthToken=" + authResult["access_token"];
     window.location.href = loc;
-  } else if (authResult['error']) {
-
+  } else if (authResult["error"]) {
     // There was an error, which means the user is not signed in.
     console.error(authResult);
     return false;
@@ -75,39 +86,34 @@ function signinCallback(authResult) {
 }
 
 function signOut(event) {
-
   //don't immediately redirect the user
   event.preventDefault();
 
   //send sign-out request to Google
   var auth2 = gapi.auth2.getAuthInstance();
-  auth2.signOut()
-    .then(function () {
-      console.log('User signed out.');
+  auth2.signOut().then(function() {
+    console.log("User signed out.");
 
-      //redirect user after confirmation of sign-out received
-      window.location.href='/';
-    }
-  );
+    //redirect user after confirmation of sign-out received
+    window.location.href = "/";
+  });
 }
 
 //don't run this outside of a browser environment (e.g., when testing in Node)
-if(typeof window !== 'undefined') {
-
+if (typeof window !== "undefined") {
   // Code in this anonymous function is immediately invoked once this script loads:
   (function() {
-
     //when the sign-out link is clicked, the signOut function is executed
-    var signOutLink = document.getElementById('signOut');
-    signOutLink.addEventListener('click', signOut);
-  }());
+    var signOutLink = document.getElementById("signOut");
+    signOutLink.addEventListener("click", signOut);
+  })();
 }
-  
+
 // Export all named, top-level functions for use in unit tests.
 // The leading if statement should prevent this block from running in the browser.
-if (typeof module !== 'undefined' && module.exports) {
+if (typeof module !== "undefined" && module.exports) {
   module.exports = {
-    handleError: handleError,
+    displayError: displayError,
     onSignIn: onSignIn,
     signOut: signOut
   };

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,23 +1,3 @@
-// display error messages as alert elements in browser
-function displayError(message) {
-
-  //allow for direct input of error objects:
-  if (message instanceof Error) {
-    message = message.message;
-  }
-
-  //select a container for the alert
-  var alertContainer = document.querySelector(".alert-container");
-
-  //build a new DOM element
-  var alert = document.createElement("div");
-  alert.className = `alert alert-danger alert-dismissible fade in`;
-  alert.innerHTML = `<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Error: </strong>${message}`;
-
-  //append the new DOM element to the container
-  alertContainer.appendChild(alert);
-}
-
 // TODO: Finish this function and call it on successful sign-in.
 function onSignIn(googleUser) {
   // Build an object with the data we wish to send to server
@@ -113,7 +93,6 @@ if (typeof window !== "undefined") {
 // The leading if statement should prevent this block from running in the browser.
 if (typeof module !== "undefined" && module.exports) {
   module.exports = {
-    displayError: displayError,
     onSignIn: onSignIn,
     signOut: signOut
   };

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -1,0 +1,36 @@
+// display error messages as Bootstrap alert elements in browser
+// Bootstrap will handle closing them
+function displayError(message) {
+
+  //allow for direct input of error objects:
+  if (message instanceof Error) {
+    message = message.message;
+  }
+
+  //select a container for the alert
+  var alertContainer = document.querySelector(".alert-container");
+
+  //build a new DOM element
+  var alert = document.createElement("div");
+  alert.className = `alert alert-danger alert-dismissible fade in`;
+  alert.innerHTML = `<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><strong>Error: </strong>${message}`;
+
+  //append the new DOM element to the container
+  alertContainer.appendChild(alert);
+}
+
+//don't run this outside of a browser environment (e.g., when testing in Node)
+if (typeof window !== "undefined") {
+  // Code in this anonymous function is immediately invoked once this script loads:
+  (function() {
+    console.log('base.js loaded');
+  })();
+}
+
+// Export all named, top-level functions for use in unit tests.
+// The leading if statement should prevent this block from running in the browser.
+if (typeof module !== "undefined" && module.exports) {
+  module.exports = {
+    displayError: displayError
+  };
+}

--- a/templates/layouts/base.html
+++ b/templates/layouts/base.html
@@ -12,13 +12,14 @@
     {% endblock %}
   </head>
   <body>
-    
+
     {% block content %}
     
     {% endblock %}
 
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa" crossorigin="anonymous"></script>
+    <script src="/static/js/base.js"></script>
 
     {% block scriptContent %}
     

--- a/templates/layouts/org-layout.html
+++ b/templates/layouts/org-layout.html
@@ -27,7 +27,8 @@
       </div>
     </div>
   </nav>
-
+  <div class="alert-container"></div>
+  
   {% block contentInner %}
   
   {% endblock %}

--- a/templates/layouts/vol-layout.html
+++ b/templates/layouts/vol-layout.html
@@ -29,7 +29,8 @@
       </div>
     </div>
   </nav>
-
+  <div class="alert-container"></div>
+  
   {% block contentInner %}
   
   {% endblock %}

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -15,6 +15,7 @@
         <a class="pull-right" href="/">Return to homepage</a>
       </div>
     </div>
+    <div class="alert-container"></div>
     <div class="row">
       <h2>Organization Sign-Up</h2>
     </div>

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -8,6 +8,7 @@
 
 {% block content %}
 
+<div class="alert-container"></div>
 <div class="container-outer">
   <div class="container">
     <div class="row">
@@ -15,7 +16,6 @@
         <a class="pull-right" href="/">Return to homepage</a>
       </div>
     </div>
-    <div class="alert-container"></div>
     <div class="row">
       <h2>Organization Sign-Up</h2>
     </div>

--- a/tests/js/auth.test.js
+++ b/tests/js/auth.test.js
@@ -4,25 +4,55 @@ var JSDOM = jsdom.JSDOM;
 
 // import browser code to be tested
 var auth = require("../../static/js/auth.js");
+var sourceUrl = "http://localhost:5000/org/login";
 
 //collect tests that require DOM access here:
 tap.test("Log-in page", function(test) {
 
   // JSDOM will create a DOM object from the HTML at the provided URL.
   // This allows us to simulate a browser environment.
-  var url = "http://localhost:5000/org/login";
-  JSDOM.fromURL(url).then(dom => {
-    var document = dom.window.document;
+  JSDOM.fromURL(sourceUrl).then(dom => {
+    global.document = dom.window.document;
 
-    //tests that the returned DOM actually reflects the given page
-    test.ok(document.querySelector('.container'),
-      'DOM includes a container div'
+    //tests that the starting DOM actually reflects the given page
+    test.ok(document.querySelector('.alert-container'),
+      'DOM includes an alert-container div'
     );
+
+    test.notOk(document.querySelector('.alert'),
+      'Before invoking displayError, DOM does not include an alert div'
+    );
+
+    //invoke function being tested
+    var stringInput = 'test string input';
+    auth.displayError(stringInput);
+
+    test.ok(document.querySelector('.alert'),
+      'After invoking displayError with string, DOM includes an alert div'
+    );
+
+    var displayedMessage = document.querySelector('.alert').lastChild.nodeValue;
+    test.equal(stringInput, displayedMessage, 'Alert div displays message passed as string to displayError');
+    
+    //always include t.end() in a collection of child tests
+    // test.end();
+  });
+
+  JSDOM.fromURL(sourceUrl).then(dom => {
+    global.document = dom.window.document;
+
+    //invoke function being tested
+    var errorInput = new Error('test error object input');
+    auth.displayError(errorInput);
+
+    test.ok(document.querySelector('.alert'),
+      'After invoking displayError with error object, DOM includes an alert div'
+    );
+
+    var displayedMessage = document.querySelector('.alert').lastChild.nodeValue;
+    test.equal(errorInput.message, displayedMessage, 'Alert div displays message passed as error object to displayError');
     
     //always include t.end() in a collection of child tests
     test.end();
   })
-  .catch(err => {
-    console.error(`Error: Tests for ${url} did not run. Is the Flask app running on localhost:5000?`);
-  });
 });

--- a/tests/js/base.test.js
+++ b/tests/js/base.test.js
@@ -3,7 +3,7 @@ var jsdom = require("jsdom");
 var JSDOM = jsdom.JSDOM;
 
 // import browser code to be tested
-var auth = require("../../static/js/auth.js");
+var frontEndCode = require("../../static/js/base.js");
 var sourceUrl = "http://localhost:5000/org/login";
 
 //collect tests that require DOM access here:
@@ -25,7 +25,7 @@ tap.test("Log-in page", function(test) {
 
     //invoke function being tested
     var stringInput = 'test string input';
-    auth.displayError(stringInput);
+    frontEndCode.displayError(stringInput);
 
     test.ok(document.querySelector('.alert'),
       'After invoking displayError with string, DOM includes an alert div'
@@ -43,7 +43,7 @@ tap.test("Log-in page", function(test) {
 
     //invoke function being tested
     var errorInput = new Error('test error object input');
-    auth.displayError(errorInput);
+    frontEndCode.displayError(errorInput);
 
     test.ok(document.querySelector('.alert'),
       'After invoking displayError with error object, DOM includes an alert div'


### PR DESCRIPTION
- Add function, accessible on all pages, to display a dismissable Bootstrap alert with a given message
- You can try it by running displayError('your message') from the JS console of your browser
- Accepts either a string or an Error object as input.
- Fully unit-tested (yay!)

Lays groundwork for issue #52 