### PR TITLE
0.16.0 Print login requests on both server and browser consoles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Voluntr
-## Current Version: 0.15.1
+## Current Version: 0.16.0
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>
 
 # Table of Contents

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -2,14 +2,15 @@
 function onSignIn(googleUser) {
   // Build an object with the data we wish to send to server
   var profile = googleUser.getBasicProfile();
-  var id_token = googleUser.getAuthResponse().id_token;
+  var authToken = googleUser.getAuthResponse().id_token;
   var userDataToSend = {
     contactName: profile.getName(),
     email: profile.getEmail(),
-    idtoken: id_token
+    authToken: authToken
   };
 
   // build a fetch request to POST user's Google data to server for verification:
+  var authUrl = "/org/login";
   var requestOptions = {
     method: "POST",
     body: JSON.stringify(userDataToSend)
@@ -17,9 +18,6 @@ function onSignIn(googleUser) {
 
   requestOptions.headers = new Headers();
   requestOptions.headers.append("Content-Type", "application/json");
-
-  // TODO: set this:
-  var authUrl = "";
 
   // Send the request, and respond to both successful and failure outcomes:
   fetch(authUrl, requestOptions)

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -21,7 +21,7 @@
     </div>
 
     <!-- Google Sign-In button, controlled from Google's platform.js script -->
-    <div class="g-signin2" data-onsuccess="onSignInTemp" redirect-uri="signinCallback" data-theme="dark"></div>
+    <div class="g-signin2" data-onsuccess="onSignIn" redirect-uri="signinCallback" data-theme="dark"></div>
     <a href="/" id="signOut">Sign out</a>
   </div>
 </div>

--- a/voluntr.py
+++ b/voluntr.py
@@ -63,6 +63,19 @@ def show_opportunity():
     '''displays details about a specific volunteer opportunity, with option to edit/delete the opportunity''' 
     return render_template('organization/preview.html', title="Voluntr | Preview Post")
 
+@app.route("/org/login", methods=['POST'])
+def login():
+    '''process a login attempt via OAuth token'''
+    print ('\nLogin route received data: ', request.get_json())
+    print ('\nOAuth token to parse: ', request.get_json()["authToken"])
+    return redirect('/')
+
+@app.route("/org/signup", methods=['POST'])
+def signup():
+    '''process a sign-up attempt with an Oauth token and some form data'''
+    print ('Signup route received data: ', request)
+    return redirect('/')
+
 @app.route("/drop_create", methods=['GET'])
 def dropCreate():
     db.drop_all()

--- a/voluntr.py
+++ b/voluntr.py
@@ -73,7 +73,7 @@ def login():
 @app.route("/org/signup", methods=['POST'])
 def signup():
     '''process a sign-up attempt with an Oauth token and some form data'''
-    print (']nSignup route received data: ', request)
+    print ('\nSignup route received data: ', request)
     return redirect('/')
 
 @app.route("/drop_create", methods=['GET'])

--- a/voluntr.py
+++ b/voluntr.py
@@ -66,9 +66,10 @@ def show_opportunity():
 @app.route("/org/login", methods=['POST'])
 def login():
     '''process a login attempt via OAuth token'''
+    token = request.get_json()["authToken"]
     print ('\nLogin route received data: ', request.get_json())
-    print ('\nOAuth token to parse: ', request.get_json()["authToken"])
-    return json.jsonify({"message": "All is well.", "token": request.get_json()["authToken"]})
+    print ('\nOAuth token to parse: ', token)
+    return json.jsonify({"message": "All is well.", "token": token})
 
 @app.route("/org/signup", methods=['POST'])
 def signup():

--- a/voluntr.py
+++ b/voluntr.py
@@ -1,4 +1,4 @@
-from flask import Flask, request, redirect, render_template, flash, url_for
+from flask import Flask, request, redirect, render_template, flash, url_for, json
 from app import app, db
 from models.org import Organization, Opportunity
 from csvdata.orgcsv import add_orgs
@@ -68,12 +68,12 @@ def login():
     '''process a login attempt via OAuth token'''
     print ('\nLogin route received data: ', request.get_json())
     print ('\nOAuth token to parse: ', request.get_json()["authToken"])
-    return redirect('/')
+    return json.jsonify({"message": "All is well.", "token": request.get_json()["authToken"]})
 
 @app.route("/org/signup", methods=['POST'])
 def signup():
     '''process a sign-up attempt with an Oauth token and some form data'''
-    print ('Signup route received data: ', request)
+    print (']nSignup route received data: ', request)
     return redirect('/')
 
 @app.route("/drop_create", methods=['GET'])


### PR DESCRIPTION
After completing a Google sign-in, four things happen:

- The browser app sends the server a JSON-encoded object with the OAuth token
- The server app prints this data to the console
- The server app responds with a simple JSON object
- The browser app prints that object to its console.

This isn't the final desired behavior, but should help with keeping track of the token throughout this process.