### PR TITLE
Adds opportunity details to org homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Voluntr
-## Current Version: 0.15.1
+## Current Version: 0.16.0
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>
 
 # Table of Contents

--- a/helpers.py
+++ b/helpers.py
@@ -1,0 +1,10 @@
+import datetime
+
+def readable_date(opp_date):
+    ''' takes a single datetime input and returns a string to display along with opportunities '''
+    if opp_date == datetime.datetime(2100,1,1,23,30):
+        opp_date = "Flexible schedule"
+    else:
+        opp_date = opp_date.strftime('%A, %B %d, %Y')
+    return opp_date
+

--- a/templates/organization/opportunities.html
+++ b/templates/organization/opportunities.html
@@ -3,26 +3,36 @@
 {% block contentInner %}
   <div class="container-outer">
     <div class="container">
-      <h2>[Organization Name] Home</h2>
+      <h2>{{headerName}} | Home</h2>
       <hr>
       <div class="text-center">
         <a class="btn btn-primary btn-lg" href="./add" role="button">Post a New Opportunity</a>
       </div>
       <hr>
-      <div class="panel panel-default">
-        <div class="panel-body">
-          <h4>Opportunity 1</h4>
-          <div class="pull-right">
-            <a class="btn btn-primary" href="./edit" role="button">Edit&nbsp;
-              <div class="glyphicon glyphicon-pencil"></div>
-            </a>
-            <a class="btn btn-primary" href="./opportunity" role="button">View&nbsp;
-              <div class="glyphicon glyphicon-search"></div>
-            </a>
+    {% if opportunities|length == 0 %}
+      <p> To add your volunteer opportunity, click <a href='/add'> here!</a></p>
+    {% endif %}
+    
+    {% if opportunities|length > 0 %}
+      
+      {% for opp in opportunities %}
+        <div class="panel panel-default">
+          <div class="panel-body">
+            <h4 class="pull-left">{{opp.title}} | {{opp.startDateTime}}</h4>
+            <div class="pull-right">
+              <a class="btn btn-primary" href="./edit" role="button">Edit&nbsp;
+                <div class="glyphicon glyphicon-pencil"></div>
+              </a>
+              <a class="btn btn-primary" href="./opportunity" role="button">View&nbsp;
+                <div class="glyphicon glyphicon-search"></div>
+              </a>
+            </div>
           </div>
         </div>
-      </div>
-      <div class="panel panel-default">
+      {% endfor %}
+    
+    {% endif %}
+      <!--<div class="panel panel-default">
         <div class="panel-body">
           <h4>Opportunity 2</h4>
           <div class="pull-right">
@@ -47,7 +57,7 @@
             </a>
           </div>
         </div>
-      </div>
+      </div>-->
       </div>
     </div>
   </div>

--- a/templates/organization/opportunities.html
+++ b/templates/organization/opportunities.html
@@ -30,34 +30,7 @@
           </div>
         </div>
       {% endfor %}
-    
     {% endif %}
-      <!--<div class="panel panel-default">
-        <div class="panel-body">
-          <h4>Opportunity 2</h4>
-          <div class="pull-right">
-            <a class="btn btn-primary" href="./edit" role="button">Edit&nbsp;
-              <div class="glyphicon glyphicon-pencil"></div>
-            </a>
-            <a class="btn btn-primary" href="./opportunity" role="button">View&nbsp;
-              <div class="glyphicon glyphicon-search"></div>
-            </a>
-          </div>
-        </div>
-      </div>
-      <div class="panel panel-default">
-        <div class="panel-body">
-          <h4>Opportunity 3</h4>
-          <div class="pull-right">
-            <a class="btn btn-primary" href="./edit" role="button">Edit&nbsp;
-              <div class="glyphicon glyphicon-pencil"></div>
-            </a>
-            <a class="btn btn-primary" href="./opportunity" role="button">View&nbsp;
-              <div class="glyphicon glyphicon-search"></div>
-            </a>
-          </div>
-        </div>
-      </div>-->
       </div>
     </div>
   </div>

--- a/templates/organization/opportunities.html
+++ b/templates/organization/opportunities.html
@@ -18,7 +18,11 @@
       {% for opp in opportunities %}
         <div class="panel panel-default">
           <div class="panel-body">
-            <h4 class="pull-left">{{opp.title}} | {{opp.startDateTime}}</h4>
+            <h4>
+              {{opp.title}}
+              <br/>
+              <small>{{opp.startDateTime}}</small>
+            </h4>
             <div class="pull-right">
               <a class="btn btn-primary" href="./edit" role="button">Edit&nbsp;
                 <div class="glyphicon glyphicon-pencil"></div>

--- a/voluntr.py
+++ b/voluntr.py
@@ -44,7 +44,14 @@ def org_login():
 def manage_opportunities():
     '''displays all volunteer opportunities associated with an organization, with options to create
      new opportunities, or view an individual opportunity'''
-    return render_template('organization/opportunities.html', title="Voluntr | Opportunities")
+    # TODO: hard coding a single org id here for now. Eventually, this information will be passed to 
+    # this route by Oauth  
+    org_id = 3
+    org = Organization.query.filter_by(id=org_id).first()
+    # define variables to pass into the template
+    org_name = org.orgName
+    opps = Opportunity.query.filter_by(owner_id = org_id).all()
+    return render_template('organization/opportunities.html', title="Voluntr | Opportunities", headerName = org_name, opportunities = opps)
 
 @app.route("/org/add", methods=['GET'])
 def new_opportunity():

--- a/voluntr.py
+++ b/voluntr.py
@@ -3,6 +3,8 @@ from app import app, db
 from models.org import Organization, Opportunity
 from csvdata.orgcsv import add_orgs
 from csvdata.oppscsv import add_opportunities
+import datetime
+from helpers import readable_date
 
 # TODO - post methods to handle form data are needed on the following routes: 
 # /filters 
@@ -46,11 +48,15 @@ def manage_opportunities():
      new opportunities, or view an individual opportunity'''
     # TODO: hard coding a single org id here for now. Eventually, this information will be passed to 
     # this route by Oauth  
-    org_id = 3
+    org_id = 6
     org = Organization.query.filter_by(id=org_id).first()
     # define variables to pass into the template
     org_name = org.orgName
     opps = Opportunity.query.filter_by(owner_id = org_id).all()
+    # format datetime into more readable strings
+    for opp in opps:
+        opp.startDateTime = readable_date(opp.startDateTime)
+    
     return render_template('organization/opportunities.html', title="Voluntr | Opportunities", headerName = org_name, opportunities = opps)
 
 @app.route("/org/add", methods=['GET'])


### PR DESCRIPTION
Resolves #73.  A few notes:
- This page will need some more customization/styling. 
- For now, the organizations get a message referring them to org/add if they don't currently have opportunities listed.  
- If they have created opportunities, the org will see a list of them - both title and date are displayed.  The datetime will need to be played with a bit, but I was thinking this might be helpful if they have an opportunity with the same title occurring on multiple dates.  

Any feedback is welcome!