### PR TITLE
Resolves datetime display and conversion issues, adds org/add POST route.  

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 0.20.4
+## Current Version: 0.21.0
 
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>
 

--- a/helpers.py
+++ b/helpers.py
@@ -31,14 +31,16 @@ def readable_times(opp_datetime, duration):
 
     #determine AM or PM
     if start_hour >= 12:
-        start_hour %= 12
         start_suffix = "PM"
+        if start_hour > 12:
+            start_hour %= 12
     else:
         start_suffix = "AM"
     
     if end_hour >= 12:
-        end_hour %= 12
         end_suffix = "PM"
+        if end_hour > 12:
+            end_hour %= 12     
     else:
         end_suffix = "AM"
     
@@ -48,7 +50,7 @@ def readable_times(opp_datetime, duration):
     if end_minutes < 10:
         end_minutes = "0" + str(end_minutes)
 
-    # get start time as a string
+    # convert times to string and reformat
     start_time = str(start_hour) + ":" + str(start_minutes) + " " + start_suffix
     end_time = str(end_hour) + ":" + str(end_minutes) + " " + end_suffix
 

--- a/helpers.py
+++ b/helpers.py
@@ -1,5 +1,8 @@
 import datetime
 
+# datetime object formatting helpers
+######################################
+
 def readable_date(opp_date):
     ''' takes a single datetime input and returns a string to display along with opportunities '''
     if opp_date == datetime.datetime(2100,1,1,23,30):
@@ -8,3 +11,128 @@ def readable_date(opp_date):
         opp_date = opp_date.strftime('%A, %B %d, %Y')
     return opp_date
 
+def readable_times(opp_datetime, duration):
+    ''' takes a datetime input and an int representing duration
+    in minutes; returns a string to show the time range for an event '''
+    
+    # check for flexible schedule opportunities
+    # TODO: remove this check when test data is no longer in use
+    if duration == 0:
+        return ""
+
+    start_hour = int(opp_datetime.strftime("%H"))
+    start_minutes = int(opp_datetime.strftime("%M"))
+    end_hour = start_hour 
+    end_minutes = start_minutes + duration
+
+    if end_minutes > 60:
+        end_hour += end_minutes//60
+        end_minutes = end_minutes % 60
+
+    #determine AM or PM
+    if start_hour >= 12:
+        start_hour %= 12
+        start_suffix = "PM"
+    else:
+        start_suffix = "AM"
+    
+    if end_hour >= 12:
+        end_hour %= 12
+        end_suffix = "PM"
+    else:
+        end_suffix = "AM"
+    
+    #check for single digit minutes:
+    if start_minutes < 10:
+        start_minutes = "0" + str(start_minutes)
+    if end_minutes < 10:
+        end_minutes = "0" + str(end_minutes)
+
+    # get start time as a string
+    start_time = str(start_hour) + ":" + str(start_minutes) + " " + start_suffix
+    end_time = str(end_hour) + ":" + str(end_minutes) + " " + end_suffix
+
+    return start_time + " - " + end_time 
+
+def get_duration(start_time, end_time):
+    ''' takes 2 strings representing 'hh:mm' and returns the 
+    difference in minutes as an integer '''
+    
+    # split strings and remove the colon
+    start_list = start_time.split(":")
+    end_list = end_time.split(":")
+    
+    # convert to time to integers and multiply hours by 60 to get total in minutes
+    start_total_min = (int(start_list[0]) * 60) + int(start_list[1])
+    end_total_min = (int(end_list[0]) * 60) + int(end_list[1])
+    
+    return end_total_min - start_total_min
+
+def create_datetime(date, start_time):
+    ''' takes 2 strings as input in the forms 'YYYY-MM-DD' and 'HH:MM'
+    and returns a datetime object representing the start date and time
+    of the opportunity '''
+    
+    date_list = date.split("-")
+    time_list = start_time.split(":")
+
+    start_date_time = datetime.datetime(int(date_list[0]), int(date_list[1]),
+                                            int(date_list[2]), int(time_list[0]), 
+                                            int(time_list[1]))
+    
+    return start_date_time
+
+# Opportunity form input helpers 
+###################################
+
+def validate_opp_data():
+    return True
+
+def validate_title(title_input):
+    ''' takes a single string input and returns a placeholder title if an empty string was submitted '''
+    
+    if len(title_input) == 0:
+        return "Missing title: please contact organization for details"
+    
+    return title_input 
+
+def validate_description(input_text):
+    ''' takes a single string as input, returns a placeholder message if the input string is empty '''
+    
+    if len(input_text) == 0:
+        return "Please contact the organization at the url above for more details"
+
+    return input_text
+
+def validate_next_steps(input_text):
+    ''' takes a single string as input, returns a placeholder message if the input string is empty '''
+    
+    if len(input_text) == 0:
+        return "Please contact the organization at the url above for more details"
+
+    return input_text
+
+def get_category_class(category):
+
+    if category == "Animals": 
+        return "animals"
+    elif category == "Arts & Culture":
+        return "arts_culture"
+    elif category == "Children & Youth": 
+        return "kids_youth" 
+    elif category == "Community":
+        return "community"
+    elif category == "Education & Literacy": 
+        return "education_lit"
+    elif category == "Environment & Nature": 
+        return "environment"
+    elif category == "Health & Medicine": 
+        return "health_med"
+    elif category == "Homeless & Housing": 
+        return "houseless"
+    elif category == "Hunger": 
+        return "hunger"
+    elif category == "People with Disabilities": 
+        return "disabilities"
+    else:
+        return "unknown"

--- a/templates/organization/add.html
+++ b/templates/organization/add.html
@@ -9,76 +9,68 @@
             <h2>Post a New Opportunity</h2>
           </div>
           <div class="row">
-            <form>
+            <form action="/org/add" method="POST">
               <div class="form-group">
                 <label for="title">Title</label>
-                <input class="form-control" id="title" type="text" maxlength="120">
+                <input class="form-control" id="title" type="text" name="title" maxlength="120">
               </div>
               <div class="form-group">
                 <label for="date">Date</label>
-                <input class="form-control" id="date" type="date">
+                <input class="form-control" id="date" name="date" type="date">
               </div>
               <div class="row">
                 <div class="col-xs-6">
                   <div class="form-group">
                     <label for="startTime">Start Time</label>
-                    <input class="form-control" id="startTime" type="time" value="12:00">
+                    <input class="form-control" id="startTime" type="time" name="startTime" value="12:00">
                   </div>
                 </div>
                 <div class="col-xs-6">
                   <div class="form-group">
                     <label for="endTime">End Time</label>
-                    <input class="form-control" id="endTime" type="time" value="12:30">
+                    <input class="form-control" id="endTime" type="time" name="endTime" value="12:30">
                   </div>
                 </div>
               </div>
               <div class="form-group">
                 <label for="address">Street Address</label>
-                <input class="form-control" id="address" type="text" maxlength="120">
+                <input class="form-control" id="address" type="text" name="address" maxlength="120" required>
                 <div class="row">
                   <div class="col-xs-4">
                     <label for="city">City</label>
-                    <input class="form-control" id="city" type="text" maxlength="120">
+                    <input class="form-control" id="city" type="text" name="city" maxlength="120">
                   </div>
                   <div class="col-xs-4">
                     <label for="state">State</label>
-                    <input class="form-control" id="state" type="text" maxlength="2">
+                    <input class="form-control" id="state" type="text" name="state" maxlength="2">
                   </div>
                   <div class="col-xs-4">
                     <label for="zipCode">Zip Code</label>
-                    <input class="form-control" id="zipCode" type="text" maxlength="5">
+                    <input class="form-control" id="zipCode" type="text" name="zip" maxlength="5">
                   </div>
                 </div>
               </div>
               <div class="form-group">
                 <label for="category">Category</label>
                 <p class="help-block">Choose the one category that best fits this opportunity.</p>
+                {% for category in categories %}
                 <div class="radio">
                   <label>
-                    <input id="education" type="radio" name="category" value="education" checked="">Education
+                    <input id={{category}} type="radio" name="category" value={{category}}>{{category}}
                   </label>
                 </div>
-                <div class="radio">
-                  <label>
-                    <input id="environment" type="radio" name="category" value="environment">Environment
-                  </label>
-                </div>
-                <div class="radio">
-                  <label>
-                    <input id="poverty" type="radio" name="category" value="poverty">Poverty
-                  </label>
-                </div>
+                {% endfor %}
               </div>
               <div class="form-group">
                 <label for="description">Description</label>
-                <textarea class="form-control" id="description" maxlength="1000" rows="5"></textarea>
+                <textarea class="form-control" id="description" name="description" maxlength="1000" rows="5"></textarea>
               </div>
               <div class="form-group">
                 <label for="nextSteps">Next Steps</label>
-                <textarea class="form-control" id="nextSteps" maxlength="1000" rows="5"></textarea>
+                <textarea class="form-control" id="nextSteps" name="nextsteps" maxlength="1000" rows="5"></textarea>
               </div>
               <div class="text-center">
-                <a class="btn btn-primary" href="./opportunities" role="button">Submit</a>
+                <input type="submit" class="btn btn-primary" role="button" value="Submit Opportunity" />
               </div>
             </form>
           </div>

--- a/templates/volunteer/opportunities.html
+++ b/templates/volunteer/opportunities.html
@@ -18,7 +18,8 @@
             <h4 class="text-center">{{ opp.city }},&nbsp;{{ opp.state }}&nbsp;{{ opp.zipcode }}</h4>
           </div>
           <div class="col-xs-6">
-            <h4 class="text-center">November 9, 6:00PM - 7:30PM</h4>
+            <h4 class="text-center">{{event_date}}</h4>
+            <h4 class="text-center">{{event_time}}</h4>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This resolves issue #89 , #94, and #71.  

Updates for Volunteers:
- Volunteers browsing available opportunities now see a date and time for the event that is based on the datetime object in the db.  
- Volunteers can view new opportunities added by non-profits, not just the db sample data

Updates for Non-profits:
- Non-profits can use the Add an Opportunity form to create and post a volunteer opportunity.  
- After posting their opportunity information, the opportunity is displayed on the orgs home page,  and appears in the db and in volunteer search results.  

To do as separate issues:
- There is still a minor problem with the radio buttons in the add opportunity form, but I have a workaround in place for now.  (All new opportunities are currently posted as "Community" category.)
- There isn't any real server-side validation in place yet.  I think that implementing something like flask-WTForm would probably be a good idea.
- adding some alternative options for sections on the form would probably make it easier for organizations to accurately represent their opportunities.  Ex: instead of picking a date, have a checkbox for flexible schedule opportunities, or an option to choose something like "every 3rd Sunday from 5-7PM"