### PR TITLE
add temp link to org logged-in view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 0.21.2
+## Current Version: 0.21.4
 
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>
 

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -17,7 +17,15 @@
       </div>
     </div>
     <div class="row">
-      <h2>Organization Sign-Up</h2>
+      <div class="col-xs-12">
+        <h2>Organization Sign-Up</h2>
+      </div>
+    </div>
+
+    <!-- TODO: Remove this when account creation works -->
+    <div class="alert alert-warning">Account creation isn't working quite yet. 
+      <a href="/org/opportunities">Click here to pretend that it is</a>
+      , and visit the organization logged-in view.
     </div>
 
     <!-- Google Sign-In button, controlled from Google's platform.js script -->


### PR DESCRIPTION
- Add link to circumvent account sign-up screen until account creation actually works.

![screen shot 2017-10-21 at 8 45 30 pm](https://user-images.githubusercontent.com/15862890/31857959-d4f3c982-b6a0-11e7-9159-eb4a548ec08d.png)
