### PR TITLE
Finish org/login POST route

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 0.21.7
+## Current Version: 0.22.0
 
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>
 

--- a/helpers.py
+++ b/helpers.py
@@ -1,4 +1,6 @@
 import datetime
+from google.oauth2 import id_token
+from google.auth.transport import requests
 
 # datetime object formatting helpers
 ######################################
@@ -138,3 +140,25 @@ def get_category_class(category):
         return "disabilities"
     else:
         return "unknown"
+
+# OAuth
+######################
+
+# Check the validity of an OAuth token, and return a Google ID (if valid) or False
+def process_oauth_token(token):
+    try:
+        CLIENT_ID = "649609603099-g73psa76kgviat4mdh2ctt1pk8he11bb.apps.googleusercontent.com"
+        idinfo = id_token.verify_oauth2_token(token, requests.Request(), CLIENT_ID)
+
+        if idinfo['iss'] not in ['accounts.google.com', 'https://accounts.google.com']:
+            raise ValueError('Wrong issuer.')
+        
+        # ID token is valid. Get the user's Google Account ID from the decoded token.
+        userid = idinfo['sub']
+        print ('The userID for the OAuth token is %s'%(userid))
+        return userid
+
+    # TODO: Error handling
+    except ValueError:
+        # Invalid token
+        return

--- a/helpers.py
+++ b/helpers.py
@@ -161,4 +161,4 @@ def process_oauth_token(token):
     # TODO: Error handling
     except ValueError:
         # Invalid token
-        return
+        return None

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,11 +1,10 @@
 // TODO: Finish this function
 function onSignIn(googleUser) {
-  // Build an object with the data we wish to send to server
   var profile = googleUser.getBasicProfile();
   var authToken = googleUser.getAuthResponse().id_token;
+
+  // Build an object with the data we wish to send to server 
   var userDataToSend = {
-    contactName: profile.getName(),
-    email: profile.getEmail(),
     authToken: authToken
   };
 
@@ -28,12 +27,12 @@ function onSignIn(googleUser) {
         response
           .json()
           .then(function(responseData) {
-            console.log("Success! Server responded with: ", responseData);
+            console.log("Server responded with: ", responseData);
             
             if (responseData.valid_token && responseData.account_exists) {
               redirectToOrgHome();
             } else {
-              showSignUpForm();
+              showSignUpForm(profile.getName(), profile.getEmail());
             }
           })
           .catch(displayError);
@@ -43,8 +42,16 @@ function onSignIn(googleUser) {
 }
 
 // Executed after successful Google sign-in, with no existing Voluntr account:
-function showSignUpForm() {
+function showSignUpForm(contactName, email) {
   var signUpForm = document.querySelector('.signup-row');
+  var contactNameInput = document.getElementById('contactName');
+  var emailInput = document.getElementById('email');
+
+  //pre-populate Contact Name and Contact Email fields with data from Google account:
+  contactNameInput.value = contactName;
+  emailInput.value = email;
+
+  //display the form
   signUpForm.classList.remove("hidden");
 }
 

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -30,9 +30,7 @@ function onSignIn(googleUser) {
           .then(function(responseData) {
             console.log("Success! Server responded with: ", responseData);
             
-            //TODO: Make this conditional actually depend on server response
-            // if(response.accountExists) {
-            if (false) {
+            if (responseData.valid_token && responseData.account_exists) {
               redirectToOrgHome();
             } else {
               showSignUpForm();

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -1,4 +1,3 @@
-// TODO: Finish this function
 function onSignIn(googleUser) {
   var profile = googleUser.getBasicProfile();
   var authToken = googleUser.getAuthResponse().id_token;

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -34,7 +34,7 @@ function onSignIn(googleUser) {
               if (responseData.account_exists) {
                 redirectToOrgHome();
               } else {
-                showSignUpForm(profile.getName(), profile.getEmail());
+                showSignUpForm(profile.getName(), profile.getEmail(), authToken);
               }
             } else {
               throw Error('Received invalid Google authorization token.')
@@ -47,14 +47,16 @@ function onSignIn(googleUser) {
 }
 
 // Executed after successful Google sign-in, with no existing Voluntr account:
-function showSignUpForm(contactName, email) {
+function showSignUpForm(contactName, email, token) {
   var signUpForm = document.querySelector('.signup-row');
   var contactNameInput = document.getElementById('contactName');
   var emailInput = document.getElementById('email');
+  var tokenInput = document.getElementById('token');
 
   //pre-populate Contact Name and Contact Email fields with data from Google account:
   contactNameInput.value = contactName;
   emailInput.value = email;
+  tokenInput.value = token;
 
   //display the form
   signUpForm.classList.remove("hidden");

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -28,10 +28,16 @@ function onSignIn(googleUser) {
           .then(function(responseData) {
             console.log("Server responded with: ", responseData);
             
-            if (responseData.valid_token && responseData.account_exists) {
-              redirectToOrgHome();
+            // Based on token validity, and Voluntr account existence, either:
+            // Redirect to logged-in view, show sign-up form, or show an error message
+            if(responseData.valid_token) {
+              if (responseData.account_exists) {
+                redirectToOrgHome();
+              } else {
+                showSignUpForm(profile.getName(), profile.getEmail());
+              }
             } else {
-              showSignUpForm(profile.getName(), profile.getEmail());
+              throw Error('Received invalid Google authorization token.')
             }
           })
           .catch(displayError);

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -49,7 +49,7 @@
               </div>
               <div class="form-group">
                 <label for="orgName">Organization Name</label>
-                <input class="form-control" id="orgName" name="orgName" type="text" maxlength="120" required="required">
+                <input class="form-control" id="orgName" name="orgName" type="text" maxlength="120" required="required" autofocus="autofocus">
               </div>
               <div class="form-group">
                 <label for="url">Organization Website</label>

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -55,6 +55,8 @@
                 <label for="url">Organization Website</label>
                 <input class="form-control" id="url" name="url" type="text" maxlength="200" required="required">
               </div>
+              <!-- JavaScript will add the OAuth token to this hidden input: -->
+              <input type="hidden" id="token" name="token">
               <div class="text-center">
                 <button type="submit" form="signup-form" value="Sign Up" class="btn btn-primary">Sign Up</button>
               </div>

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -37,14 +37,22 @@
       <div class="col-xs-12">
         <div class="panel panel-default">
           <div class="panel-body">
-            <h4>Successfully connected to Google! We just need to know a few more things to create your account.</h4>
+            <h4>Successfully connected to Google! We just need to know a few things to create your account.</h4>
             <form action="/org/signup" method="post" id="signup-form">
+              <div class="form-group">
+                <label for="contactName">Contact Name</label>
+                <input class="form-control" id="contactName" name="contactName" type="text" maxlength="120" required="required">
+              </div>
+              <div class="form-group">
+                <label for="email">Contact Email</label>
+                <input class="form-control" id="email" name="email" type="text" maxlength="200" required="required">
+              </div>
               <div class="form-group">
                 <label for="orgName">Organization Name</label>
                 <input class="form-control" id="orgName" name="orgName" type="text" maxlength="120" required="required">
               </div>
               <div class="form-group">
-                <label for="url">Website</label>
+                <label for="url">Organization Website</label>
                 <input class="form-control" id="url" name="url" type="text" maxlength="200" required="required">
               </div>
               <div class="text-center">

--- a/voluntr.py
+++ b/voluntr.py
@@ -82,7 +82,7 @@ def org_login():
         
 @app.route("/org/login", methods=['POST'])
 def login():
-    '''process a login attempt via OAuth token'''
+    '''process a login attempt via OAuth token, return JSON'''
     token = request.get_json()["authToken"]
 
     # Start building a response
@@ -93,7 +93,7 @@ def login():
     if (user_id):
         response_content["valid_token"] = True
 
-        # If the token is valid, see if the ID corresponds to an existing account
+        # If the token is valid, see if the ID corresponds to an existing Voluntr account
         # TODO: Actually perform this check
         account_exists = False
 
@@ -110,7 +110,11 @@ def login():
 @app.route("/org/signup", methods=['POST'])
 def signup():
     '''process a sign-up attempt with an Oauth token and some form data'''
-    print ('\nSignup route received data: ', request)
+
+    # Expect to receive JSON-encoded data from the browser with 5 fields:
+    # token, orgName, url, contactName, email
+    # We'll convert the token to an ID with process_oauth_token()
+
     return redirect('/')
 
 

--- a/voluntr.py
+++ b/voluntr.py
@@ -1,6 +1,4 @@
 from flask import Flask, request, redirect, render_template, flash, url_for, json, make_response
-from google.oauth2 import id_token
-from google.auth.transport import requests
 from app import app, db
 from models.org import Organization, Opportunity
 from csvdata.orgcsv import add_orgs
@@ -81,33 +79,32 @@ def display_matches():
 def org_login():
     '''displays a form for organizations to signup or login to Voluntr'''
     return render_template('organization/login.html', title="Voluntr | Log In")
-
-
-
+        
 @app.route("/org/login", methods=['POST'])
 def login():
     '''process a login attempt via OAuth token'''
     token = request.get_json()["authToken"]
 
-    print ('\nLogin route received data: ', request.get_json())
-    print ('\nOAuth token to parse: ', token)
-    
-    try:
-        CLIENT_ID = "649609603099-g73psa76kgviat4mdh2ctt1pk8he11bb.apps.googleusercontent.com"
-        idinfo = id_token.verify_oauth2_token(token, requests.Request(), CLIENT_ID)
+    # Start building a response
+    response_content = {"token": token}
 
-        if idinfo['iss'] not in ['accounts.google.com', 'https://accounts.google.com']:
-            raise ValueError('Wrong issuer.')
-        
-        # ID token is valid. Get the user's Google Account ID from the decoded token.
-        userid = idinfo['sub']
-        print ('The userID for the OAuth token is %s'%(userid))
+    # Check the validity of the OAuth token:
+    user_id = process_oauth_token(token)
+    if (user_id):
+        response_content["valid_token"] = True
 
-    except ValueError:
-        # Invalid token
-        pass
+        # If the token is valid, see if the ID corresponds to an existing account
+        # TODO: Actually perform this check
+        account_exists = False
 
-    return json.jsonify({"message": "All is well.", "token": token})
+        if (account_exists):
+            response_content["account_exists"] = True
+        else:
+            response_content["account_exists"] = False
+    else:
+        response_content["valid_token"] = False
+
+    return json.jsonify(response_content)
 
 
 @app.route("/org/signup", methods=['POST'])

--- a/voluntr.py
+++ b/voluntr.py
@@ -89,15 +89,14 @@ def login():
     response_content = {"token": token}
 
     # Check the validity of the OAuth token:
-    user_id = process_oauth_token(token)
-    if (user_id):
+    google_id = process_oauth_token(token)
+    if (google_id):
         response_content["valid_token"] = True
 
         # If the token is valid, see if the ID corresponds to an existing Voluntr account
-        # TODO: Actually perform this check
-        account_exists = False
+        org_account = Organization.query.filter_by(id=google_id).first()
 
-        if (account_exists):
+        if (org_account):
             response_content["account_exists"] = True
         else:
             response_content["account_exists"] = False

--- a/voluntr.py
+++ b/voluntr.py
@@ -110,10 +110,10 @@ def login():
 def signup():
     '''process a sign-up attempt with an Oauth token and some form data'''
 
-    # Expect to receive JSON-encoded data from the browser with 5 fields:
+    # Expect to receive form data from the browser with 5 fields:
     # token, orgName, url, contactName, email
     # We'll convert the token to an ID with process_oauth_token()
-
+    print ('\nSignup route received data: ', request.form)
     return redirect('/')
 
 


### PR DESCRIPTION
- Move token validation to `helpers.py`
- `org/login` POST route now checks if received OAuth token is valid and if a Voluntr account exists for that Google ID, then responds with JSON.
- In browser, adds form fields for Contact Name and Contact Email, which are pre-populated with Google account data
- Also add hidden input for the OAuth token
- Browser displays login form or redirects to logged-in view, as appropriate

Resolves issues #83 and #85 
