### PR TITLE
fixes org opportunity view w/query params

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -1,4 +1,5 @@
 import datetime
+from models.org import Opportunity
 from google.oauth2 import id_token
 from google.auth.transport import requests
 
@@ -174,3 +175,8 @@ def get_cat_class(category):
     for key in categories.keys():
         if get_category(key) == category:
             return key
+
+# Query helpers
+###########################
+def get_opp_by_id(oppId):
+    return Opportunity.query.get(oppId)

--- a/templates/organization/opportunities.html
+++ b/templates/organization/opportunities.html
@@ -27,7 +27,7 @@
               <a class="btn btn-primary" href="./edit" role="button">Edit&nbsp;
                 <div class="glyphicon glyphicon-pencil"></div>
               </a>
-              <a class="btn btn-primary" href="./opportunity" role="button">View&nbsp;
+              <a class="btn btn-primary" href="./opportunity?id={{opp.id}}" role="button">View&nbsp;
                 <div class="glyphicon glyphicon-search"></div>
               </a>
             </div>

--- a/templates/organization/preview.html
+++ b/templates/organization/preview.html
@@ -21,26 +21,45 @@
           </div>
         </div>
       </div>
-      <div class="row opp-header">
-        <h1 class="text-center">Opportunity Title</h1>
-        <h3 class="text-center">Organization Name</h3><br><br><br>
-        <div class="row">
-          <div class="col-xs-6"> 
-            <h4 class="text-center">1234 NW Main St. </h4>
-            <h4 class="text-center">Portland, OR 97000</h4>
+      <div class="row opp-header opp-header--{{ opp.category_class }}">
+        <div class="opp-header__top">
+          <h1 class="text-center">{{ opp.title }}</h1>
+          <h3 class="text-center">{{ opp.owner.orgName }}</h3>
+        </div>
+        <div class="opp-header__bottom">
+          <div class="opp-header__bottom-left">
+            <h4 class="text-center">{{ opp.address }}</h4>
+            <h4 class="text-center">{{ opp.city }},&nbsp;{{ opp.state }}</h4>
           </div>
-          <div class="col-xs-6">
-            <h4 class="text-center">November 9, 6:00PM - 7:30PM</h4>
+          <div class="opp-header__bottom-right">
+            <h4 class="text-center">{{event_date}}</h4>
+            <h4 class="text-center">{{event_time}}</h4>
+          </div> 
+        </div>
+      </div>      
+      <div class="row">
+        <div class="text-center">
+          <div class="btn-group opp-nav-buttons" role="group" aria-label="Navigate opportunity pages">
+            <div class="btn-group" role="group">
+              <button id="save-button" class="btn btn-default">Save&nbsp;
+                <span class="glyphicon glyphicon-pushpin"></span>
+              </button>
+            </div>
+            <a class="btn btn-default" href="#" role="button">Filters&nbsp;
+              <div class="glyphicon glyphicon-search"></div>
+            </a>
+            <a class="btn btn-default" href="#" role="button">Next&nbsp;
+              <div class="glyphicon glyphicon-play"></div>
+            </a>
           </div>
         </div>
       </div>
-      <hr>
       <div class="row">
-        <p><strong>Location:&nbsp;</strong>1234 NW Main St. Portland, OR 97000</p>
-        <p><strong>Organization website:&nbsp;</strong><a href="http://google.com">http://google.com</a></p>
-        <p><strong>When:&nbsp;</strong>November 9, 6:00PM - 7:30PM</p>
-        <p> <strong>About:&nbsp;</strong>Oregon Food Bank volunteers contribute to our mission in many valuable ways. Volunteer opportunities at our Portland and Beaverton locations include: repackaging food, leading nutrition education classes, maintaining our learning gardens, helping out in our offices, lending a hand at events, and more! Most volunteer opportunities are 2-3 hours in length and do not require a regular commitment.</p>
-        <p><strong>Next steps:&nbsp;</strong>If you're interested, Lorem ipsum dolor sit amet, consectetur adipisicing elit. Maiores accusantium ad velit iure adipisci necessitatibus eos assumenda sequi aliquam quae repellendus deleniti optio quos reiciendis dignissimos, in distinctio pariatur blanditiis eaque vero nisi illo labore recusandae incidunt quasi. Possimus, asperiores accusamus molestiae blanditiis, nesciunt deleniti beatae, ea error illo consequatur libero numquam ipsam sit eligendi quaerat et reprehenderit incidunt tenetur alias? Perferendis doloremque, aperiam quibusdam inventore iure officia? Enim dolore sunt tempore officia accusantium animi, sed quis nobis aut delectus, mollitia quisquam error ipsa quo eligendi rem. Ab doloribus ipsa minima quasi culpa voluptate asperiores dolorem. Rerum possimus voluptatum reiciendis!</p>
+        <p><strong>Location:&nbsp;</strong>{{ opp.address }}, {{ opp.city }},&nbsp;{{ opp.state }}&nbsp;{{ opp.zipcode }}</p>
+        <p><strong>Website:&nbsp;</strong><a href={{opp.owner.url}}>{{opp.owner.url}}</a></p>
+        <p><strong>When:&nbsp;</strong>{{event_date}}, {{event_time}}</p>
+        <p> <strong>About:&nbsp;</strong>{{ opp.description }}</p>
+        <p><strong>Next steps:&nbsp;</strong>{{ opp.nextSteps }}</p>
       </div>
     </div>
   </div>

--- a/voluntr.py
+++ b/voluntr.py
@@ -207,8 +207,13 @@ def edit_opportunity():
 
 @app.route("/org/opportunity", methods=['GET'])
 def show_opportunity():
-    '''displays details about a specific volunteer opportunity, with option to edit/delete the opportunity''' 
-    return render_template('organization/preview.html', title="Voluntr | Preview Post")
+    '''displays details about a specific volunteer opportunity''' 
+    id = request.args.get("id", type=int)
+    opp = get_opp_by_id(id) 
+    event_date = readable_date(opp.startDateTime)
+    event_time = readable_times(opp.startDateTime, opp.duration)
+    return render_template('organization/preview.html', title="Voluntr | Preview Post", opp=opp, 
+                                event_date = event_date, event_time = event_time)
 
 
 # Run this route upon app startup to load sample data


### PR DESCRIPTION
Resolves #118

This allows the organizations to preview an individual opportunity.  Instead of using a form to pass the opportunity ID to the template, I added it as a query parameter attached to the "View" button on org/opportunities.  I'm not sure if exposing the id would be a bad practice or not, but it seemed like the simplest solution for now.  

I think that a edit/back button options might be more appropriate for this page than the edit/delete buttons, but I will leave that to future discussion.

@AdamD-2096 thanks for the helper function :)   