### PR TITLE
Display "Flexible Schedule" without trailing comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 0.25.1
+## Current Version: 0.25.3
 
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>
 

--- a/templates/organization/preview.html
+++ b/templates/organization/preview.html
@@ -57,7 +57,11 @@
       <div class="row">
         <p><strong>Location:&nbsp;</strong>{{ opp.address }}, {{ opp.city }},&nbsp;{{ opp.state }}&nbsp;{{ opp.zipcode }}</p>
         <p><strong>Website:&nbsp;</strong><a href={{opp.owner.url}}>{{opp.owner.url}}</a></p>
-        <p><strong>When:&nbsp;</strong>{{event_date}}, {{event_time}}</p>
+        {% if event_time %}
+            <p><strong>When:&nbsp;</strong>{{event_date}}, {{event_time}}</p>
+        {% else %}
+            <p><strong>When:&nbsp;</strong>{{event_date}}</p>
+        {% endif %}
         <p> <strong>About:&nbsp;</strong>{{ opp.description }}</p>
         <p><strong>Next steps:&nbsp;</strong>{{ opp.nextSteps }}</p>
       </div>

--- a/templates/volunteer/opportunities.html
+++ b/templates/volunteer/opportunities.html
@@ -46,7 +46,11 @@
       <div class="row">
         <p><strong>Location:&nbsp;</strong>{{ opp.address }}, {{ opp.city }},&nbsp;{{ opp.state }}&nbsp;{{ opp.zipcode }}</p>
         <p><strong>Website:&nbsp;</strong><a href={{opp.owner.url}}>{{opp.owner.url}}</a></p>
-        <p><strong>When:&nbsp;</strong>{{event_date}}, {{event_time}}</p>
+        {% if event_time %}
+            <p><strong>When:&nbsp;</strong>{{event_date}}, {{event_time}}</p>
+        {% else %}
+            <p><strong>When:&nbsp;</strong>{{event_date}}</p>
+        {% endif %}
         <p> <strong>About:&nbsp;</strong>{{ opp.description }}</p>
         <p><strong>Next steps:&nbsp;</strong>{{ opp.nextSteps }}</p>
       </div>

--- a/templates/volunteer/single_opp.html
+++ b/templates/volunteer/single_opp.html
@@ -31,7 +31,11 @@
       <div class="row">
         <p><strong>Location:&nbsp;</strong>{{ opp.address }}, {{ opp.city }},&nbsp;{{ opp.state }}&nbsp;{{ opp.zipcode }}</p>
         <p><strong>Website:&nbsp;</strong><a href={{opp.owner.url}}>{{opp.owner.url}}</a></p>
-        <p><strong>When:&nbsp;</strong>{{event_date}}, {{event_time}}</p>
+        {% if event_time %}
+            <p><strong>When:&nbsp;</strong>{{event_date}}, {{event_time}}</p>
+        {% else %}
+            <p><strong>When:&nbsp;</strong>{{event_date}}</p>
+        {% endif %}
         <p> <strong>About:&nbsp;</strong>{{ opp.description }}</p>
         <p><strong>Next steps:&nbsp;</strong>{{ opp.nextSteps }}</p>
       </div>


### PR DESCRIPTION
Fixes bug from issue #150 