### PR TITLE
Allow search by zip code + distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 0.25.1
+## Current Version: 0.26.0
 
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>
 

--- a/filters.py
+++ b/filters.py
@@ -1,7 +1,7 @@
 from app import db
 from models.org import Opportunity
 from helpers import get_day
-from pyzipcode import ZipCodeDatabase
+from pyzipcode import ZipCodeDatabase, ZipNotFoundException
 
 zcdb = ZipCodeDatabase()
 
@@ -42,11 +42,18 @@ class Filters():
         return filtered
 
     def filter_by_location(self, opps):
-        filtered = []
-        zips = zcdb.get_zipcodes_around_radius(self.zipcode, self.distance)
-        for i in range(len(opps)):
-            for j in range (len(zips)):
-                if opps[i].zipcode == zips[j].zip:
-                    filtered = filtered + [opps[i]]
+        try:
+            filtered = []
+            zips = zcdb.get_zipcodes_around_radius(self.zipcode, self.distance)
+            for i in range(len(opps)):
+                for j in range (len(zips)):
+                    if opps[i].zipcode == zips[j].zip:
+                        filtered = filtered + [opps[i]]
+            return filtered
+        except ZipNotFoundException:
+            #TODO Send meaningful feedback to browser. For now, it's just ignoring the location filter
+            print('Zip code not found.')
+            return opps
+            
                 
-        return filtered
+        

--- a/filters.py
+++ b/filters.py
@@ -25,7 +25,6 @@ class Filters():
             opps = self.filter_by_days(opps)
 
         if self.zipcode != "all" and self.distance != "all":
-            print ("RUNNING", self.zipcode, self.distance)
             opps = self.filter_by_location(opps)
 
         return opps

--- a/filters.py
+++ b/filters.py
@@ -7,11 +7,11 @@ zcdb = ZipCodeDatabase()
 
 class Filters():
 
-    def __init__(self, category="all", availability=["all"], zip="97232", distance=5):
+    def __init__(self, category="all", availability=["all"], zipcode="97232", distance=5):
 
         self.category = category
         self.availability = availability
-        self.zip = zip
+        self.zipcode = zipcode
         self.distance = distance
 
     def search(self):
@@ -25,7 +25,7 @@ class Filters():
         if self.availability[0] != "all" and len(self.availability) != 7:
             opps = self.filter_by_days(opps)
 
-        opps = self.filter_by_zip(opps)
+        opps = self.filter_by_location(opps)
 
         return opps
 
@@ -40,9 +40,9 @@ class Filters():
                         filtered = filtered + [opps[i]]
         return filtered
 
-    def filter_by_zip(self, opps):
+    def filter_by_location(self, opps):
         filtered = []
-        zips = zcdb.get_zipcodes_around_radius(self.zip, self.distance)
+        zips = zcdb.get_zipcodes_around_radius(self.zipcode, self.distance)
         for i in range(len(opps)):
             for j in range (len(zips)):
                 if opps[i].zipcode == zips[j].zip:

--- a/filters.py
+++ b/filters.py
@@ -1,13 +1,18 @@
 from app import db
 from models.org import Opportunity
 from helpers import get_day
+from pyzipcode import ZipCodeDatabase
+
+zcdb = ZipCodeDatabase()
 
 class Filters():
 
-    def __init__(self, category="all", availability=["all"]):
+    def __init__(self, category="all", availability=["all"], zip="97232", distance=5):
 
         self.category = category
         self.availability = availability
+        self.zip = zip
+        self.distance = distance
 
     def search(self):
         if self.category == "all":
@@ -20,6 +25,8 @@ class Filters():
         if self.availability[0] != "all" and len(self.availability) != 7:
             opps = self.filter_by_days(opps)
 
+        opps = self.filter_by_zip(opps)
+
         return opps
 
     def filter_by_days(self, opps):
@@ -31,4 +38,14 @@ class Filters():
                 for j in range (len(self.availability)):
                     if get_day(opps[i].startDateTime) == self.availability[j]:
                         filtered = filtered + [opps[i]]
+        return filtered
+
+    def filter_by_zip(self, opps):
+        filtered = []
+        zips = zcdb.get_zipcodes_around_radius(self.zip, self.distance)
+        for i in range(len(opps)):
+            for j in range (len(zips)):
+                if opps[i].zipcode == zips[j].zip:
+                    filtered = filtered + [opps[i]]
+                
         return filtered

--- a/filters.py
+++ b/filters.py
@@ -7,7 +7,7 @@ zcdb = ZipCodeDatabase()
 
 class Filters():
 
-    def __init__(self, category="all", availability=["all"], zipcode="97232", distance=5):
+    def __init__(self, category="all", availability=["all"], zipcode="all", distance="all"):
 
         self.category = category
         self.availability = availability
@@ -21,11 +21,12 @@ class Filters():
         else:
             opps = Opportunity.query.filter_by(category_class=self.category).all()
 
-
         if self.availability[0] != "all" and len(self.availability) != 7:
             opps = self.filter_by_days(opps)
 
-        opps = self.filter_by_location(opps)
+        if self.zipcode != "all" and self.distance != "all":
+            print ("RUNNING", self.zipcode, self.distance)
+            opps = self.filter_by_location(opps)
 
         return opps
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,4 @@ google_auth==1.1.1
 pymysql==0.7.11
 protobuf==3.4.0
 requests==2.18.4
-
+pyzipcode3==2.0

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -86,11 +86,16 @@ body {
 .days-table {
   max-width: 400px;
 }
-/*Fit the days-of-week table onto very small screens:*/
+
+/*Tweaks to fit things onto very small screens:*/
 @media (max-width: 400px) {
   table.table.days-table thead td {
     padding-left: 0;
     padding-right: 0;
+  }
+
+  select.form-control {
+    padding: 0px;
   }
 }
 

--- a/templates/volunteer/filters.html
+++ b/templates/volunteer/filters.html
@@ -8,7 +8,6 @@
           <div class="panel panel-default">
             <div class="panel-body">
 
-
                   <div class="form-group">
                     <label for="category">Show me opportunities related to:</label>
                     <div class="radio">
@@ -24,8 +23,6 @@
                       </div>
                       {% endfor %}
                   </div>
-                  <!-- <br /> -->
-
 
                   <div class="form-group">
                     <label for="available">On any of these days:&nbsp;</label>
@@ -54,8 +51,6 @@
                       </tbody>
                     </table>
                   </div>
-                  <!-- <br /> -->
-
 
                   <div class="row">
                     <div class="col-xs-6">
@@ -76,12 +71,11 @@
                     <div class="col-xs-6">
                       <div class="form-group">
                         <label for="zipcode">Of zip code:</label>
-                        <input name="zipcode" class="form-control" id="zipcode" type="text" placeholder="Zip Code" maxlength="5">
+                        <input name="zipcode" class="form-control" id="zipcode" type="text" placeholder="Zip Code" maxlength="5" pattern="[0-9]{5}" title="Please enter exactly 5 numerical digits." >
                       </div>
                     </div>
                   </div>
                   <br />
-
 
               <div class="text-center">
                 <button type="submit" form="filters-form" value="Sign Up" class="btn btn-primary">Browse Opportunities</button>

--- a/templates/volunteer/filters.html
+++ b/templates/volunteer/filters.html
@@ -24,7 +24,7 @@
                       </div>
                       {% endfor %}
                   </div>
-                  <br />
+                  <!-- <br /> -->
 
 
                   <div class="form-group">
@@ -54,28 +54,28 @@
                       </tbody>
                     </table>
                   </div>
-                  <br />
+                  <!-- <br /> -->
 
 
                   <div class="row">
                     <div class="col-xs-6">
                       <div class="form-group">
-                        <label for="distance">Within (miles) of:</label>
+                        <label for="distance">Within:</label>
                         <select name="distance" id="distance" class="form-control" >
-                          <option value="all" selected="selected">Any</option>
-                          <option>1</option>
-                          <option>2</option>
-                          <option>5</option>
-                          <option>10</option>
-                          <option>15</option>
-                          <option>20</option>
-                          <option>30</option>
+                          <option value="all" selected="selected">Any Distance</option>
+                          <option>1 Mile</option>
+                          <option>2 Miles</option>
+                          <option>5 Miles</option>
+                          <option>10 Miles</option>
+                          <option>15 Miles</option>
+                          <option>20 Miles</option>
+                          <option>30 Miles</option>
                         </select>
                       </div>
                     </div>
                     <div class="col-xs-6">
                       <div class="form-group">
-                        <label for="zipcode">Zip Code:</label>
+                        <label for="zipcode">Of zip code:</label>
                         <input name="zipcode" class="form-control" id="zipcode" type="text" placeholder="Zip Code" maxlength="5">
                       </div>
                     </div>

--- a/templates/volunteer/filters.html
+++ b/templates/volunteer/filters.html
@@ -7,88 +7,89 @@
         <form action="/filters" method="post" id="filters-form">
           <div class="panel panel-default">
             <div class="panel-body">
-              <div class="form-group">
-                <label for="category">Show me opportunities related to:</label>
-                <div class="radio">
-                <label>
-                  <input id="all" type="radio" name="category" value="all" checked="checked">Any Category
-                </label>
-                </div>
-                  {% for key, value in categories.items() %}
-                  <div class="radio">
+
+
+                  <div class="form-group">
+                    <label for="category">Show me opportunities related to:</label>
+                    <div class="radio">
                     <label>
-                      <input id="{{key}}" type="radio" name="category" value="{{key}}">{{value}}
+                      <input id="all" type="radio" name="category" value="all" checked="checked">Any Category
                     </label>
+                    </div>
+                      {% for key, value in categories.items() %}
+                      <div class="radio">
+                        <label>
+                          <input id="{{key}}" type="radio" name="category" value="{{key}}">{{value}}
+                        </label>
+                      </div>
+                      {% endfor %}
                   </div>
-                  {% endfor %}
-              </div>
-            </div>
-          </div>
+                  <br />
 
-          <div class="panel panel-default">
-            <div class="panel-body">
-              <div class="form-group">
-                <label for="available">Available Days:&nbsp;</label>
-                <table class="table table-bordered table-condensed days-table text-center">
-                  <thead>
-                    <tr class="text-center">
-                      <td class="text-center">Sun</td>
-                      <td class="text-center">Mon</td>
-                      <td class="text-center">Tue</td>
-                      <td class="text-center">Wed</td>
-                      <td class="text-center">Thu</td>
-                      <td class="text-center">Fri</td>
-                      <td class="text-center">Sat</td>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <tr>
-                      <td><input id="sun" type="checkbox" name="availableDays" value="Sunday" checked="checked"></td>
-                      <td><input id="sun" type="checkbox" name="availableDays" value="Monday" checked="checked"></td>
-                      <td><input id="sun" type="checkbox" name="availableDays" value="Tuesday" checked="checked"></td>
-                      <td><input id="sun" type="checkbox" name="availableDays" value="Wednesday" checked="checked"></td>
-                      <td><input id="sun" type="checkbox" name="availableDays" value="Thursday" checked="checked"></td>
-                      <td><input id="sun" type="checkbox" name="availableDays" value="Friday" checked="checked"></td>
-                      <td><input id="sun" type="checkbox" name="availableDays" value="Saturday" checked="checked"></td>
-                    </tr>
-                  </tbody>
-                </table>
-              </div>
-            </div>
-          </div>
 
-          <div class="panel panel-default">
-            <div class="panel-body">
-              <div class="row">
-                <div class="col-xs-6">
                   <div class="form-group">
-                    <label for="zipcode">Zip Code</label>
-                    <input name="zipcode" class="form-control" id="zipcode" type="text" placeholder="Zip Code" maxlength="5">
+                    <label for="available">On any of these days:&nbsp;</label>
+                    <table class="table table-bordered table-condensed days-table text-center">
+                      <thead>
+                        <tr class="text-center">
+                          <td class="text-center">Sun</td>
+                          <td class="text-center">Mon</td>
+                          <td class="text-center">Tue</td>
+                          <td class="text-center">Wed</td>
+                          <td class="text-center">Thu</td>
+                          <td class="text-center">Fri</td>
+                          <td class="text-center">Sat</td>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        <tr>
+                          <td><input id="sun" type="checkbox" name="availableDays" value="Sunday" checked="checked"></td>
+                          <td><input id="sun" type="checkbox" name="availableDays" value="Monday" checked="checked"></td>
+                          <td><input id="sun" type="checkbox" name="availableDays" value="Tuesday" checked="checked"></td>
+                          <td><input id="sun" type="checkbox" name="availableDays" value="Wednesday" checked="checked"></td>
+                          <td><input id="sun" type="checkbox" name="availableDays" value="Thursday" checked="checked"></td>
+                          <td><input id="sun" type="checkbox" name="availableDays" value="Friday" checked="checked"></td>
+                          <td><input id="sun" type="checkbox" name="availableDays" value="Saturday" checked="checked"></td>
+                        </tr>
+                      </tbody>
+                    </table>
                   </div>
-                </div>
-                <div class="col-xs-6">
-                  <div class="form-group">
-                    <label for="distance">Distance (miles)</label>
-                    <select name="distance" id="distance" class="form-control" >
-                      <option>1</option>
-                      <option>2</option>
-                      <option selected="selected">5</option>
-                      <option>10</option>
-                      <option>15</option>
-                      <option>20</option>
-                      <option>25</option>
-                      <option>30</option>
-                      <option value="all">Any</option>
-                    </select>
+                  <br />
+
+
+                  <div class="row">
+                    <div class="col-xs-6">
+                      <div class="form-group">
+                        <label for="distance">Within (miles) of:</label>
+                        <select name="distance" id="distance" class="form-control" >
+                          <option value="all" selected="selected">Any</option>
+                          <option>1</option>
+                          <option>2</option>
+                          <option>5</option>
+                          <option>10</option>
+                          <option>15</option>
+                          <option>20</option>
+                          <option>30</option>
+                        </select>
+                      </div>
+                    </div>
+                    <div class="col-xs-6">
+                      <div class="form-group">
+                        <label for="zipcode">Zip Code:</label>
+                        <input name="zipcode" class="form-control" id="zipcode" type="text" placeholder="Zip Code" maxlength="5">
+                      </div>
+                    </div>
                   </div>
-                </div>
+                  <br />
+
+
+              <div class="text-center">
+                <button type="submit" form="filters-form" value="Sign Up" class="btn btn-primary">Browse Opportunities</button>
               </div>
             </div>
           </div>
 
-          <div class="text-center">
-            <button type="submit" form="filters-form" value="Sign Up" class="btn btn-primary">Browse Opportunities</button>
-          </div>
+          
         </form>
 
     </div>

--- a/templates/volunteer/filters.html
+++ b/templates/volunteer/filters.html
@@ -7,13 +7,13 @@
       <div class="panel panel-default">
         <div class="panel-body">
           <form action="/filters" method="post" id="filters-form">
-            <div class="form-group hidden">
+            <div class="form-group">
               <label for="zipcode">Zip Code</label>
               <input name="zipcode" class="form-control" id="zipcode" type="text" placeholder="Zip Code" maxlength="5">
             </div>
-            <div class="form-group hidden">
+            <div class="form-group">
               <label for="distance">Distance (miles)</label>
-              <input name="distance" id="distance" type="range" min="1" max="50" value="10">
+              <input name="distance" id="distance" type="range" min="1" max="10" value="5">
             </div>
             <div class="form-group">
               <label for="category">Show me opportunities related to:</label>

--- a/templates/volunteer/filters.html
+++ b/templates/volunteer/filters.html
@@ -58,13 +58,13 @@
                         <label for="distance">Within:</label>
                         <select name="distance" id="distance" class="form-control" >
                           <option value="all" selected="selected">Any Distance</option>
-                          <option>1 Mile</option>
-                          <option>2 Miles</option>
-                          <option>5 Miles</option>
-                          <option>10 Miles</option>
-                          <option>15 Miles</option>
-                          <option>20 Miles</option>
-                          <option>30 Miles</option>
+                          <option value=1>1 Mile</option>
+                          <option value=2>2 Miles</option>
+                          <option value=5>5 Miles</option>
+                          <option value=10>10 Miles</option>
+                          <option value=15>15 Miles</option>
+                          <option value=20>20 Miles</option>
+                          <option value=30>30 Miles</option>
                         </select>
                       </div>
                     </div>

--- a/templates/volunteer/filters.html
+++ b/templates/volunteer/filters.html
@@ -4,66 +4,93 @@
   <div class="container-outer">
     <div class="container">
       <h2>My Search Preferences</h2>
-      <div class="panel panel-default">
-        <div class="panel-body">
-          <form action="/filters" method="post" id="filters-form">
-            <div class="form-group">
-              <label for="zipcode">Zip Code</label>
-              <input name="zipcode" class="form-control" id="zipcode" type="text" placeholder="Zip Code" maxlength="5">
-            </div>
-            <div class="form-group">
-              <label for="distance">Distance (miles)</label>
-              <input name="distance" id="distance" type="range" min="1" max="10" value="5">
-            </div>
-            <div class="form-group">
-              <label for="category">Show me opportunities related to:</label>
-              <div class="radio">
-              <label>
-                <input id="all" type="radio" name="category" value="all" checked="checked">Any Category
-              </label>
-              </div>
-                {% for key, value in categories.items() %}
+        <form action="/filters" method="post" id="filters-form">
+          <div class="panel panel-default">
+            <div class="panel-body">
+              <div class="form-group">
+                <label for="category">Show me opportunities related to:</label>
                 <div class="radio">
-                  <label>
-                    <input id="{{key}}" type="radio" name="category" value="{{key}}">{{value}}
-                  </label>
+                <label>
+                  <input id="all" type="radio" name="category" value="all" checked="checked">Any Category
+                </label>
                 </div>
-                {% endfor %}
+                  {% for key, value in categories.items() %}
+                  <div class="radio">
+                    <label>
+                      <input id="{{key}}" type="radio" name="category" value="{{key}}">{{value}}
+                    </label>
+                  </div>
+                  {% endfor %}
+              </div>
             </div>
-            <br />
-            <div class="form-group">
-              <label for="available">Available Days:&nbsp;</label>
-              <table class="table table-bordered table-condensed days-table text-center">
-                <thead>
-                  <tr class="text-center">
-                    <td class="text-center">Sun</td>
-                    <td class="text-center">Mon</td>
-                    <td class="text-center">Tue</td>
-                    <td class="text-center">Wed</td>
-                    <td class="text-center">Thu</td>
-                    <td class="text-center">Fri</td>
-                    <td class="text-center">Sat</td>
-                  </tr>
-                </thead>
-                <tbody>
-                  <tr>
-                    <td><input id="sun" type="checkbox" name="availableDays" value="Sunday" checked="checked"></td>
-                    <td><input id="sun" type="checkbox" name="availableDays" value="Monday" checked="checked"></td>
-                    <td><input id="sun" type="checkbox" name="availableDays" value="Tuesday" checked="checked"></td>
-                    <td><input id="sun" type="checkbox" name="availableDays" value="Wednesday" checked="checked"></td>
-                    <td><input id="sun" type="checkbox" name="availableDays" value="Thursday" checked="checked"></td>
-                    <td><input id="sun" type="checkbox" name="availableDays" value="Friday" checked="checked"></td>
-                    <td><input id="sun" type="checkbox" name="availableDays" value="Saturday" checked="checked"></td>
-                  </tr>
-                </tbody>
-              </table>
+          </div>
+
+          <div class="panel panel-default">
+            <div class="panel-body">
+              <div class="form-group">
+                <label for="available">Available Days:&nbsp;</label>
+                <table class="table table-bordered table-condensed days-table text-center">
+                  <thead>
+                    <tr class="text-center">
+                      <td class="text-center">Sun</td>
+                      <td class="text-center">Mon</td>
+                      <td class="text-center">Tue</td>
+                      <td class="text-center">Wed</td>
+                      <td class="text-center">Thu</td>
+                      <td class="text-center">Fri</td>
+                      <td class="text-center">Sat</td>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr>
+                      <td><input id="sun" type="checkbox" name="availableDays" value="Sunday" checked="checked"></td>
+                      <td><input id="sun" type="checkbox" name="availableDays" value="Monday" checked="checked"></td>
+                      <td><input id="sun" type="checkbox" name="availableDays" value="Tuesday" checked="checked"></td>
+                      <td><input id="sun" type="checkbox" name="availableDays" value="Wednesday" checked="checked"></td>
+                      <td><input id="sun" type="checkbox" name="availableDays" value="Thursday" checked="checked"></td>
+                      <td><input id="sun" type="checkbox" name="availableDays" value="Friday" checked="checked"></td>
+                      <td><input id="sun" type="checkbox" name="availableDays" value="Saturday" checked="checked"></td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
             </div>
-            <div class="text-center">
-              <button type="submit" form="filters-form" value="Sign Up" class="btn btn-primary">Browse Opportunities</button>
+          </div>
+
+          <div class="panel panel-default">
+            <div class="panel-body">
+              <div class="row">
+                <div class="col-xs-6">
+                  <div class="form-group">
+                    <label for="zipcode">Zip Code</label>
+                    <input name="zipcode" class="form-control" id="zipcode" type="text" placeholder="Zip Code" maxlength="5">
+                  </div>
+                </div>
+                <div class="col-xs-6">
+                  <div class="form-group">
+                    <label for="distance">Distance (miles)</label>
+                    <select name="distance" id="distance" class="form-control" >
+                      <option>1</option>
+                      <option>2</option>
+                      <option selected="selected">5</option>
+                      <option>10</option>
+                      <option>15</option>
+                      <option>20</option>
+                      <option>25</option>
+                      <option>30</option>
+                      <option value="all">Any</option>
+                    </select>
+                  </div>
+                </div>
+              </div>
             </div>
-          </form>
-        </div>
-      </div>
+          </div>
+
+          <div class="text-center">
+            <button type="submit" form="filters-form" value="Sign Up" class="btn btn-primary">Browse Opportunities</button>
+          </div>
+        </form>
+
     </div>
   </div>
 {% endblock %}     

--- a/voluntr.py
+++ b/voluntr.py
@@ -71,8 +71,10 @@ def opportunities():
         category = filters[1] # grabs category from list
         avail = filters[2] # grabs available days
         availability = avail.split("-") # splits into list
+        zipcode = filters[3] #grabs zipcode from list
+        distance = filters[4] #grabs distance from list
 
-        search = Filters(category=category, availability=availability) # creates filter with given category and availability
+        search = Filters(category=category, availability=availability, zipcode=zipcode, distance=distance) # creates filter with given category and availability
         opps = search.search() #grabs list of opportunities
         opp = opps[num] # picks out the opp at index
         
@@ -87,7 +89,7 @@ def opportunities():
         resp = make_response(render_template('volunteer/opportunities.html', 
                                             opp=opp, event_date = event_date, event_time=event_time, json=json, title="Voluntr | Browse Opportunities")
                                             ) # tells the cookie what to load while it sets itself
-        resp.set_cookie('filters', str(num) + "," + category + "," + avail) #preps cookie for setting
+        resp.set_cookie('filters', str(num) + "," + category + "," + avail + "," + zipcode + "," + distance ) #preps cookie for setting
         return resp # sets cookie and displays page
     
     return redirect("/filters") # redirects to filters if no cookie exists
@@ -173,7 +175,7 @@ def new_opportunity():
         address = request.form["address"]
         city = request.form["city"]
         state = request.form["state"]
-        zip_code = request.form["zip"]
+        zip_code = request.form["zipcode"]
         category_class = request.form["category"]
         category = get_category(category_class)
         description = validate_description(request.form["description"])

--- a/voluntr.py
+++ b/voluntr.py
@@ -36,7 +36,11 @@ def set_filters():
             availability = ["all"] # if no list of available days in form data, set to ["all"]
 
         if 'zipcode' in request.form.keys(): # if zipcode was in form sent. assign it to var
-            zipcode = request.form['zipcode']   
+            if len(request.form['zipcode']) == 5:
+                zipcode = request.form['zipcode']
+            else:
+                zipcode = "all"
+                
         else:
             zipcode = "all" # if no zipcode in form data, set to "all"
 

--- a/voluntr.py
+++ b/voluntr.py
@@ -35,12 +35,22 @@ def set_filters():
         else:
             availability = ["all"] # if no list of available days in form data, set to ["all"]
 
+        if 'zipcode' in request.form.keys(): # if zipcode was in form sent. assign it to var
+            zipcode = request.form['zipcode']   
+        else:
+            zipcode = "all" # if no zipcode in form data, set to "all"
+
+        if 'distance' in request.form.keys(): # if distance was in form sent. assign it to var
+            distance = request.form['distance']   
+        else:
+            distance = "all" # if no distance in form data, set to "all"
+
         avail = ""
         for i in range(len(availability)):
             avail = avail + availability[i] + "-"
 
         resp = make_response(redirect("/opportunities")) # tells the cookie to redirect to /opp after setting cookie
-        resp.set_cookie('filters', str("0," + category + "," + avail)) # prepares cookie to be set with index of zero
+        resp.set_cookie('filters', str("0," + category + "," + avail + "," + zipcode + "," + distance )) # prepares cookie to be set with index of zero
         
         return resp # sets cookie and redirects
 


### PR DESCRIPTION
**Note:** to run this version, you'll need to run
```pip install pyzipcode3```
in your Voluntr environment. (I also added it to `requirements.txt`.)

- Allow filtering by zip code, plus a distance from some central location in that zip code (as computed by a new dependency: `pyzipcode3`)
- Change display of zip code, distance inputs on filters form
- Require exactly 5 numerical digits for a zip code
- Default to "all" when either distance or zip code missing
- Default to "all" when zip code doesn't exist (temporary, see issue #149)
- Crashes when no matching opps found (see issue #149)