### PR TITLE
Set token cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 0.28.1
+## Current Version: 0.29.0
 
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>
 

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -33,6 +33,9 @@ function onSignIn(googleUser) {
             // Redirect to logged-in view, show sign-up form, or show an error message
             if(responseData.valid_token) {
               if (responseData.account_exists) {
+
+                //add token to cookie, then redirect to logged-in view
+                document.cookie = `token=${responseData.token}; path=/`;
                 redirectToOrgHome();
               } else {
                 showSignUpForm(profile.getName(), profile.getEmail(), authToken);

--- a/voluntr.py
+++ b/voluntr.py
@@ -139,7 +139,7 @@ def login():
         response_content["valid_token"] = True
 
         # If the token is valid, see if the ID corresponds to an existing Voluntr account
-        org_account = Organization.query.filter_by(id=userid).first()
+        org_account = Organization.query.filter_by(userid=userid).first()
 
         if (org_account):
             response_content["account_exists"] = True
@@ -177,6 +177,7 @@ def signup():
         db.session.add(new_user)
         db.session.commit()
     
+    # redirect user to logged-in view, and set cookie with OAuth token:
     resp = make_response(redirect("/org/opportunities"))
     resp.set_cookie('token', token)
     return resp

--- a/voluntr.py
+++ b/voluntr.py
@@ -166,6 +166,7 @@ def signup():
     # call process_oauth_token to convert token to google id
     userid = process_oauth_token(token)
 
+
     # retrieve the user data from the database 
     user = Organization.query.filter_by(id=userid).first()
     
@@ -176,17 +177,9 @@ def signup():
         db.session.add(new_user)
         db.session.commit()
     
-    #if userid is in database, redirect to org homepage
-    if (user):
-
-        return redirect('/org/opportunities')
-   
-    # Expect to receive form data from the browser with 5 fields:
-    # token, orgName, url, contactName, email
-    # We'll convert the token to an ID with process_oauth_token()
-    print ('\nSignup route received data: ', request.form)
-
-    return redirect('/org/opportunities')
+    resp = make_response(redirect("/org/opportunities"))
+    resp.set_cookie('token', token)
+    return resp
 
 
 @app.route("/org/opportunities", methods=['GET'])


### PR DESCRIPTION
When user signs up for a new account, set a cookie for their OAuth token with Flask. When they log in to an existing account, set the cookie from `auth.js` in the browser.

Resolves issue #171.