### PR TITLE
Add sign-out feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 0.29.0
+## Current Version: 0.30.0
 
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 0.28.1
+## Current Version: 0.29.0
 
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>
 

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -33,6 +33,9 @@ function onSignIn(googleUser) {
             // Redirect to logged-in view, show sign-up form, or show an error message
             if(responseData.valid_token) {
               if (responseData.account_exists) {
+
+                //add token to cookie, then redirect to logged-in view
+                document.cookie = `token=${responseData.token}; path=/`;
                 redirectToOrgHome();
               } else {
                 showSignUpForm(profile.getName(), profile.getEmail(), authToken);

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -80,9 +80,7 @@ if (typeof window !== "undefined") {
   // Code in this anonymous function is immediately invoked once this script loads:
   (function() {
     console.log('auth.js loaded');
-    //when the sign-out link is clicked, the signOut function is executed
-    var signOutLink = document.getElementById("signOut");
-    signOutLink.addEventListener("click", signOut);
+
   })();
 }
 

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -27,7 +27,6 @@ function onSignIn(googleUser) {
         response
           .json()
           .then(function(responseData) {
-            console.log("Server responded with: ", responseData);
             
             // Based on token validity, and Voluntr account existence, either:
             // Redirect to logged-in view, show sign-up form, or show an error message

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -19,6 +19,11 @@ function displayError(message) {
   alertContainer.appendChild(alert);
 }
 
+// helper function to delete a cookie by setting its expiration date in the past
+function deleteCookie(name) {
+  document.cookie = name +'=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+}
+
 // Sign out of Google connection, then redirect to "/"
 function signOut(event) {
   //don't immediately redirect the user
@@ -28,6 +33,9 @@ function signOut(event) {
   var auth2 = gapi.auth2.getAuthInstance();
   auth2.signOut().then(function() {
     console.log("User signed out.");
+
+    //delete the OAuth token from browser cookies:
+    deleteCookie('token');
 
     //redirect user after confirmation of sign-out received
     window.location.href = "/";

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -39,10 +39,13 @@ if (typeof window !== "undefined") {
   
   // Code in this anonymous function is immediately invoked once this script loads:
   (function() {
+
+    //when the sign-out link is clicked, the signOut function is executed
+    if (window.location.pathname.substring(0,4) === "/org") {
+      var signOutLink = document.getElementById("signOut");
+      signOutLink.addEventListener("click", signOut);
+    }
     
-
-
-
   })();
 }
 

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -31,8 +31,8 @@ function signOut(event) {
 
   //send sign-out request to Google
   var auth2 = gapi.auth2.getAuthInstance();
+  auth2.disconnect();
   auth2.signOut().then(function() {
-    console.log("User signed out.");
 
     //delete the OAuth token from browser cookies:
     deleteCookie('token');
@@ -49,8 +49,8 @@ if (typeof window !== "undefined") {
   (function() {
 
     //when the sign-out link is clicked, the signOut function is executed
-    if (window.location.pathname.substring(0,4) === "/org") {
-      var signOutLink = document.getElementById("signOut");
+    var signOutLink = document.getElementById("signOut");
+    if (signOutLink) {
       signOutLink.addEventListener("click", signOut);
     }
     

--- a/templates/layouts/org-layout.html
+++ b/templates/layouts/org-layout.html
@@ -7,7 +7,7 @@
 {% endblock %}
 
 {% block content %}
-
+  <div class="g-signin2 hidden" data-onsuccess="onSignIn" data-theme="dark" data-longtitle="true" data-height="50" data-width="300"></div>
   <nav class="navbar navbar-default navbar-static-top">
     <div class="container-fluid">
       <div class="navbar-header">
@@ -33,8 +33,8 @@
           </li>
         </ul>
         <ul class="nav navbar-nav navbar-right">
-          <li id="signOut">
-            <a href="./">Sign Out</a>
+          <li>
+            <a href="./" id="signOut">Sign Out</a>
           </li>
         </ul>
       </div>

--- a/templates/layouts/org-layout.html
+++ b/templates/layouts/org-layout.html
@@ -1,5 +1,11 @@
 {% extends "layouts/base.html" %}
 
+{% block headContent %}
+  <meta name="google-signin-scope" content="profile email">
+  <meta name="google-signin-client_id" content="649609603099-g73psa76kgviat4mdh2ctt1pk8he11bb.apps.googleusercontent.com">
+  <script src="https://apis.google.com/js/platform.js" async defer></script>
+{% endblock %}
+
 {% block content %}
 
   <nav class="navbar navbar-default navbar-static-top">
@@ -26,7 +32,11 @@
             <a href="./add">New Opportunity</a>
           </li>
         </ul>
-        <ul class="nav navbar-nav navbar-right"></ul>
+        <ul class="nav navbar-nav navbar-right">
+          <li id="signOut">
+            <a href="./">Sign Out</a>
+          </li>
+        </ul>
       </div>
     </div>
   </nav>

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -22,12 +22,6 @@
       </div>
     </div>
 
-    <!-- TODO: Remove this when account creation works -->
-    <div class="alert alert-warning">Account creation isn't working quite yet. 
-      <a href="/org/opportunities">Click here to pretend that it is</a>
-      , and visit the organization logged-in view.
-    </div>
-
     <!-- Google Sign-In button, controlled from Google's platform.js script -->
     <div class="g-signin2" data-onsuccess="onSignIn" data-theme="dark" data-longtitle="true" data-height="50" data-width="300"></div>
     

--- a/voluntr.py
+++ b/voluntr.py
@@ -139,7 +139,7 @@ def login():
         response_content["valid_token"] = True
 
         # If the token is valid, see if the ID corresponds to an existing Voluntr account
-        org_account = Organization.query.filter_by(id=userid).first()
+        org_account = Organization.query.filter_by(userid=userid).first()
 
         if (org_account):
             response_content["account_exists"] = True
@@ -177,6 +177,7 @@ def signup():
         db.session.add(new_user)
         db.session.commit()
     
+    # redirect user to logged-in view, and set cookie with OAuth token:
     resp = make_response(redirect("/org/opportunities"))
     resp.set_cookie('token', token)
     return resp

--- a/voluntr.py
+++ b/voluntr.py
@@ -166,6 +166,7 @@ def signup():
     # call process_oauth_token to convert token to google id
     userid = process_oauth_token(token)
 
+
     # retrieve the user data from the database 
     user = Organization.query.filter_by(id=userid).first()
     
@@ -176,17 +177,9 @@ def signup():
         db.session.add(new_user)
         db.session.commit()
     
-    #if userid is in database, redirect to org homepage
-    if (user):
-
-        return redirect('/org/opportunities')
-   
-    # Expect to receive form data from the browser with 5 fields:
-    # token, orgName, url, contactName, email
-    # We'll convert the token to an ID with process_oauth_token()
-    print ('\nSignup route received data: ', request.form)
-
-    return redirect('/org/opportunities')
+    resp = make_response(redirect("/org/opportunities"))
+    resp.set_cookie('token', token)
+    return resp
 
 
 @app.route("/org/opportunities", methods=['GET'])


### PR DESCRIPTION
- Org Navbar now contains Sign Out link, which deletes token cookie, and requires renewal of credentials for next Google sign-in.
- Removes placeholder bypass link from Login page. We no longer need to pretend that account authorization is working!

Resolves issue #97 