### PR TITLE
Login layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 0.36.2
+## Current Version: 0.36.3
 
 
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 0.36.1
+## Current Version: 0.36.2
 
 
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -69,6 +69,10 @@ p.help-block {
   margin: 5px 0;
 }
 
+.g-signin2 {
+  margin-top: 20px;
+}
+
 /*Uses code from Bootstrap's btn-justified class, only on small screens:*/
 @media (max-width: 768px) {
   .opp-nav-buttons {

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -69,7 +69,11 @@ function showSignUpForm(contactName, email, token) {
 // Executed after successful Google sign-in to an existing Voluntr account:
 function redirectToOrgHome() {
   var redirectRow = document.querySelector('.redirect-row');
+  var googleDiv = document.querySelector('.g-signin2');
+
   redirectRow.classList.remove("hidden");
+  googleDiv.classList.add("hidden");
+  
   setTimeout(function() {
     window.location.href="/org/opportunities";    
   }, 1200);

--- a/static/js/auth.js
+++ b/static/js/auth.js
@@ -51,6 +51,7 @@ function onSignIn(googleUser) {
 // Executed after successful Google sign-in, with no existing Voluntr account:
 function showSignUpForm(contactName, email, token) {
   var signUpForm = document.querySelector('.signup-row');
+  var googleDiv = document.querySelector('.g-signin2');
   var contactNameInput = document.getElementById('contactName');
   var emailInput = document.getElementById('email');
   var tokenInput = document.getElementById('token');
@@ -60,8 +61,9 @@ function showSignUpForm(contactName, email, token) {
   emailInput.value = email;
   tokenInput.value = token;
 
-  //display the form
+  //display the form, hide the Google sign-in button
   signUpForm.classList.remove("hidden");
+  googleDiv.classList.add("hidden");
 }
 
 // Executed after successful Google sign-in to an existing Voluntr account:

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -63,20 +63,20 @@
               <h4>Successfully connected to Google! We just need to know a few things to create your account.</h4>
               <form action="/org/signup" method="post" id="signup-form">
                 <div class="form-group">
-                  <label for="contactName">Contact Name</label>
-                  <input class="form-control" id="contactName" name="contactName" type="text" maxlength="120" required="required">
-                </div>
-                <div class="form-group">
-                  <label for="email">Contact Email</label>
-                  <input class="form-control" id="email" name="email" type="text" maxlength="200" required="required">
-                </div>
-                <div class="form-group">
                   <label for="orgName">Organization Name</label>
                   <input class="form-control" id="orgName" name="orgName" type="text" maxlength="120" required="required" autofocus="autofocus">
                 </div>
                 <div class="form-group">
                   <label for="url">Organization Website</label>
                   <input class="form-control" id="url" name="url" type="text" maxlength="200" required="required">
+                </div>
+                <div class="form-group">
+                  <label for="contactName">Contact Name</label>
+                  <input class="form-control" id="contactName" name="contactName" type="text" maxlength="120" required="required">
+                </div>
+                <div class="form-group">
+                  <label for="email">Contact Email</label>
+                  <input class="form-control" id="email" name="email" type="text" maxlength="200" required="required">
                 </div>
                 <!-- JavaScript will add the OAuth token to this hidden input: -->
                 <input type="hidden" id="token" name="token">

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -32,9 +32,9 @@
     <!-- Only visible after successful sign-in to existing account: -->
     <br />
     <div class="row redirect-row hidden">
-      <div class="col-xs-12 col-sm-6 col-sm-offset-3 col-md-4 col-md-offset-4 text-center">
-        <div class="alert alert-success" role="alert">
-          <span class="glyphicon glyphicon-ok"></span>&nbsp;&nbsp;Login successful, loading homepage...
+      <div class="col-xs-12 col-sm-6 col-sm-offset-3 text-center">
+        <div class="well">
+          <p class="lead">Login successful, loading homepage...</p>
         </div>
       </div>
     </div>

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -25,7 +25,6 @@
         <h2>Organization Sign-Up</h2>
       </div>
     </div>
-    <br />
 
     <!-- Google Sign-In button, controlled from Google's platform.js script -->
     <div class="center g-signin2" data-onsuccess="onSignIn" data-theme="dark" data-longtitle="true" data-height="50" data-width="300"></div>
@@ -41,70 +40,71 @@
     </div>
 
     <!-- Only visible after connecting to Google without a Voluntr account: -->
-    <div class="row signup-row">
-      <div class="col-xs-12 col-md-8 col-md-offset-2 centered-form">
+    <div class="row signup-row hidden">
+      <div class="col-xs-12 col-md-10 col-md-offset-1 centered-form">
         <p class="lead text-center">Successfully connected to Google! We just need to know a few things to create your Voluntr account.</p>
-        <br />
-        <form action="/org/signup" method="post" id="signup-form">
-          <div class="row">
-            <div class="col-xs-12 col-sm-4">
-              <label for="orgName">
-                <h3>Organization Name</h3>
-              </label>
+        <div class="well">          
+          <form action="/org/signup" method="post" id="signup-form">
+            <div class="row">
+              <div class="col-xs-12 col-sm-4">
+                <label for="orgName">
+                  <h3>Organization Name</h3>
+                </label>
+              </div>
+              <div class="col-xs-12 col-sm-8">
+                <input class="form-control" id="orgName" name="orgName" type="text" maxlength="120" required="required">
+              </div>
             </div>
-            <div class="col-xs-12 col-sm-8">
-              <input class="form-control" id="orgName" name="orgName" type="text" maxlength="120" required="required">
-              
-            </div>
-          </div>
-          <br />
-          <br class="hidden-xs" />
+            <br />
+            <br class="hidden-xs" />
 
-          <div class="row">
-            <div class="col-xs-12 col-sm-4">
-              <label for="url">
-                <h3>Organization Website</h3>
-              </label>
+            <div class="row">
+              <div class="col-xs-12 col-sm-4">
+                <label for="url">
+                  <h3>Organization Website</h3>
+                </label>
+              </div>
+              <div class="col-xs-12 col-sm-8">
+                <input class="form-control" id="url" name="url" type="text" maxlength="200" required="required">
+              </div>
             </div>
-            <div class="col-xs-12 col-sm-8">
-              <input class="form-control" id="url" name="url" type="text" maxlength="200" required="required">
-            </div>
-          </div>
-          <br />
-          <br class="hidden-xs" />
+            <br />
+            <br class="hidden-xs" />
 
-          <div class="row">
-            <div class="col-xs-12 col-sm-4">
-              <label for="contactName">
-                <h3>Contact Name</h3>
-              </label>
+            <div class="row">
+              <div class="col-xs-12 col-sm-4">
+                <label for="contactName">
+                  <h3>Contact Name</h3>
+                </label>
+              </div>
+              <div class="col-xs-12 col-sm-8">
+                <input class="form-control" id="contactName" name="contactName" type="text" maxlength="120" required="required">
+              </div>
             </div>
-            <div class="col-xs-12 col-sm-8">
-              <input class="form-control" id="contactName" name="contactName" type="text" maxlength="120" required="required">
-            </div>
-          </div>
-          <br />
-          <br class="hidden-xs" />
+            <br />
+            <br class="hidden-xs" />
 
-          <div class="row">
-            <div class="col-xs-12 col-sm-4">
-              <label for="email">
-                <h3>Contact Email</h3>
-              </label>
+            <div class="row">
+              <div class="col-xs-12 col-sm-4">
+                <label for="email">
+                  <h3>Contact Email</h3>
+                </label>
+              </div>
+              <div class="col-xs-12 col-sm-8">
+                <input class="form-control" id="email" name="email" type="text" maxlength="200" required="required">
+              </div>
             </div>
-            <div class="col-xs-12 col-sm-8">
-              <input class="form-control" id="email" name="email" type="text" maxlength="200" required="required">
+            <br />
+            <br class="hidden-xs" />
+            
+            <!-- JavaScript will add the OAuth token to this hidden input: -->
+            <input type="hidden" id="token" name="token">
+            <div class="text-center">
+              <button type="submit" form="signup-form" value="Sign Up" class="btn btn-primary">Sign Up</button>
             </div>
-          </div>
-          <br />
-          <br class="hidden-xs" />
-          
-          <!-- JavaScript will add the OAuth token to this hidden input: -->
-          <input type="hidden" id="token" name="token">
-          <div class="text-center">
-            <button type="submit" form="signup-form" value="Sign Up" class="btn btn-primary">Sign Up</button>
-          </div>
-        </form>
+          </form>
+          <a href="/" class="signOutLink">Switch Google accounts</a>
+        </div>
       </div>
     </div>
     

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -34,6 +34,40 @@
         </div>
       </div>
     </div>
+
+    <!-- Only visible after connecting to Google without a Voluntr account: -->
+    <div class="row signup-row hidden">
+      <div class="col-xs-12">
+        <div class="panel panel-default">
+          <div class="panel-body">
+            <h4>Successfully connected to Google! We just need to know a few things to create your Voluntr account.</h4>
+            <form action="/org/signup" method="post" id="signup-form">
+              <div class="form-group">
+                <label for="orgName">Organization Name</label>
+                <input class="form-control" id="orgName" name="orgName" type="text" maxlength="120" required="required" autofocus="autofocus">
+              </div>
+              <div class="form-group">
+                <label for="url">Organization Website</label>
+                <input class="form-control" id="url" name="url" type="text" maxlength="200" required="required">
+              </div>
+              <div class="form-group">
+                <label for="contactName">Contact Name</label>
+                <input class="form-control" id="contactName" name="contactName" type="text" maxlength="120" required="required">
+              </div>
+              <div class="form-group">
+                <label for="email">Contact Email</label>
+                <input class="form-control" id="email" name="email" type="text" maxlength="200" required="required">
+              </div>
+              <!-- JavaScript will add the OAuth token to this hidden input: -->
+              <input type="hidden" id="token" name="token">
+              <div class="text-center">
+                <button type="submit" form="signup-form" value="Sign Up" class="btn btn-primary">Sign Up</button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
     
     <br />
     <div class="row">
@@ -63,43 +97,7 @@
         <br>
         <p class="text-center lead">Voluntr!</p>
       </div>
-
       <br />
-      <div class="row signup-row fade in hidden">
-        <div class="col-xs-12">
-          <div class="panel panel-default">
-            <div class="panel-body">
-              <h4>Successfully connected to Google! We just need to know a few things to create your account.</h4>
-              <form action="/org/signup" method="post" id="signup-form">
-                <div class="form-group">
-                  <label for="orgName">Organization Name</label>
-                  <input class="form-control" id="orgName" name="orgName" type="text" maxlength="120" required="required" autofocus="autofocus">
-                </div>
-                <div class="form-group">
-                  <label for="url">Organization Website</label>
-                  <input class="form-control" id="url" name="url" type="text" maxlength="200" required="required">
-                </div>
-                <div class="form-group">
-                  <label for="contactName">Contact Name</label>
-                  <input class="form-control" id="contactName" name="contactName" type="text" maxlength="120" required="required">
-                </div>
-                <div class="form-group">
-                  <label for="email">Contact Email</label>
-                  <input class="form-control" id="email" name="email" type="text" maxlength="200" required="required">
-                </div>
-                <!-- JavaScript will add the OAuth token to this hidden input: -->
-                <input type="hidden" id="token" name="token">
-                <div class="text-center">
-                  <button type="submit" form="signup-form" value="Sign Up" class="btn btn-primary">Sign Up</button>
-                </div>
-              </form>
-            </div>
-          </div>
-        </div>
-        <div class="col-xs-12">
-          <a href="/" id="signOut">Sign out</a>
-        </div>
-      </div>
       
     </div>
   </div>

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -1,7 +1,12 @@
-{% extends "layouts/base.html" %} {% block headContent %}
-<meta name="google-signin-scope" content="profile email">
-<meta name="google-signin-client_id" content="649609603099-g73psa76kgviat4mdh2ctt1pk8he11bb.apps.googleusercontent.com">
-<script src="https://apis.google.com/js/platform.js" async defer></script> {% endblock %} {% block content %}
+{% extends "layouts/base.html" %} 
+
+{% block headContent %}
+  <meta name="google-signin-scope" content="profile email">
+  <meta name="google-signin-client_id" content="649609603099-g73psa76kgviat4mdh2ctt1pk8he11bb.apps.googleusercontent.com">
+  <script src="https://apis.google.com/js/platform.js" async defer></script> 
+{% endblock %} 
+
+{% block content %}
 <nav class="navbar navbar-default navbar-static-top">
   <div class="container-fluid">
     <div class="navbar-header">
@@ -36,36 +41,70 @@
     </div>
 
     <!-- Only visible after connecting to Google without a Voluntr account: -->
-    <div class="row signup-row hidden">
-      <div class="col-xs-12">
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <h4>Successfully connected to Google! We just need to know a few things to create your Voluntr account.</h4>
-            <form action="/org/signup" method="post" id="signup-form">
-              <div class="form-group">
-                <label for="orgName">Organization Name</label>
-                <input class="form-control" id="orgName" name="orgName" type="text" maxlength="120" required="required" autofocus="autofocus">
-              </div>
-              <div class="form-group">
-                <label for="url">Organization Website</label>
-                <input class="form-control" id="url" name="url" type="text" maxlength="200" required="required">
-              </div>
-              <div class="form-group">
-                <label for="contactName">Contact Name</label>
-                <input class="form-control" id="contactName" name="contactName" type="text" maxlength="120" required="required">
-              </div>
-              <div class="form-group">
-                <label for="email">Contact Email</label>
-                <input class="form-control" id="email" name="email" type="text" maxlength="200" required="required">
-              </div>
-              <!-- JavaScript will add the OAuth token to this hidden input: -->
-              <input type="hidden" id="token" name="token">
-              <div class="text-center">
-                <button type="submit" form="signup-form" value="Sign Up" class="btn btn-primary">Sign Up</button>
-              </div>
-            </form>
+    <div class="row signup-row">
+      <div class="col-xs-12 col-md-8 col-md-offset-2 centered-form">
+        <p class="lead text-center">Successfully connected to Google! We just need to know a few things to create your Voluntr account.</p>
+        <br />
+        <form action="/org/signup" method="post" id="signup-form">
+          <div class="row">
+            <div class="col-xs-12 col-sm-4">
+              <label for="orgName">
+                <h3>Organization Name</h3>
+              </label>
+            </div>
+            <div class="col-xs-12 col-sm-8">
+              <input class="form-control" id="orgName" name="orgName" type="text" maxlength="120" required="required">
+              
+            </div>
           </div>
-        </div>
+          <br />
+          <br class="hidden-xs" />
+
+          <div class="row">
+            <div class="col-xs-12 col-sm-4">
+              <label for="url">
+                <h3>Organization Website</h3>
+              </label>
+            </div>
+            <div class="col-xs-12 col-sm-8">
+              <input class="form-control" id="url" name="url" type="text" maxlength="200" required="required">
+            </div>
+          </div>
+          <br />
+          <br class="hidden-xs" />
+
+          <div class="row">
+            <div class="col-xs-12 col-sm-4">
+              <label for="contactName">
+                <h3>Contact Name</h3>
+              </label>
+            </div>
+            <div class="col-xs-12 col-sm-8">
+              <input class="form-control" id="contactName" name="contactName" type="text" maxlength="120" required="required">
+            </div>
+          </div>
+          <br />
+          <br class="hidden-xs" />
+
+          <div class="row">
+            <div class="col-xs-12 col-sm-4">
+              <label for="email">
+                <h3>Contact Email</h3>
+              </label>
+            </div>
+            <div class="col-xs-12 col-sm-8">
+              <input class="form-control" id="email" name="email" type="text" maxlength="200" required="required">
+            </div>
+          </div>
+          <br />
+          <br class="hidden-xs" />
+          
+          <!-- JavaScript will add the OAuth token to this hidden input: -->
+          <input type="hidden" id="token" name="token">
+          <div class="text-center">
+            <button type="submit" form="signup-form" value="Sign Up" class="btn btn-primary">Sign Up</button>
+          </div>
+        </form>
       </div>
     </div>
     
@@ -103,5 +142,7 @@
   </div>
 
   </body>
-  {% endblock %} {% block scriptContent %}
-  <script src="/static/js/auth.js"></script> {% endblock %}
+  {% endblock %} 
+  {% block scriptContent %}
+    <script src="/static/js/auth.js"></script> 
+  {% endblock %}

--- a/templates/organization/login.html
+++ b/templates/organization/login.html
@@ -13,7 +13,6 @@
 </nav>
 
 <div class="alert-container"></div>
-<div class="alert-container"></div>
 <div class="container-outer">
   <div class="container">
     <div class="row">
@@ -25,7 +24,17 @@
 
     <!-- Google Sign-In button, controlled from Google's platform.js script -->
     <div class="center g-signin2" data-onsuccess="onSignIn" data-theme="dark" data-longtitle="true" data-height="50" data-width="300"></div>
+
+    <!-- Only visible after successful sign-in to existing account: -->
     <br />
+    <div class="row redirect-row hidden">
+      <div class="col-xs-12 col-sm-6 col-sm-offset-3 col-md-4 col-md-offset-4 text-center">
+        <div class="alert alert-success" role="alert">
+          <span class="glyphicon glyphicon-ok"></span>&nbsp;&nbsp;Login successful, loading homepage...
+        </div>
+      </div>
+    </div>
+    
     <br />
     <div class="row">
       <div class="text-center">
@@ -91,15 +100,7 @@
           <a href="/" id="signOut">Sign out</a>
         </div>
       </div>
-      <div class="row redirect-row fade in hidden">
-        <div class="col-xs-12">
-          <div class="panel panel-default">
-            <div class="panel-body">
-              <h4>Log in successful, loading homepage...</h4>
-            </div>
-          </div>
-        </div>
-      </div>
+      
     </div>
   </div>
 

--- a/templates/organization/profile.html
+++ b/templates/organization/profile.html
@@ -11,32 +11,6 @@
           <form action="/org/profile" id="update-profile" method="POST">
             <div class="row">
               <div class="col-xs-12 col-sm-4">
-                <label for="contactName">
-                  <h3>Contact Name</h3>
-                </label>
-              </div>
-              <div class="col-xs-12 col-sm-8">
-                <input class="form-control" id="contactName" name="contactName" type="text" maxlength="120" required="required" value="{{org.contactName}}">
-              </div>
-            </div>
-            <br />
-            <br class="hidden-xs" />
-
-            <div class="row">
-              <div class="col-xs-12 col-sm-4">
-                <label for="email">
-                  <h3>Contact Email</h3>
-                </label>
-              </div>
-              <div class="col-xs-12 col-sm-8">
-                <input class="form-control" id="email" name="email" type="text" maxlength="200" required="required" value="{{org.email}}">
-              </div>
-            </div>
-            <br />
-            <br class="hidden-xs" />
-
-            <div class="row">
-              <div class="col-xs-12 col-sm-4">
                 <label for="orgName">
                   <h3>Organization Name</h3>
                 </label>
@@ -62,6 +36,32 @@
             <br />
             <br class="hidden-xs" />
 
+            <div class="row">
+              <div class="col-xs-12 col-sm-4">
+                <label for="contactName">
+                  <h3>Contact Name</h3>
+                </label>
+              </div>
+              <div class="col-xs-12 col-sm-8">
+                <input class="form-control" id="contactName" name="contactName" type="text" maxlength="120" required="required" value="{{org.contactName}}">
+              </div>
+            </div>
+            <br />
+            <br class="hidden-xs" />
+
+            <div class="row">
+              <div class="col-xs-12 col-sm-4">
+                <label for="email">
+                  <h3>Contact Email</h3>
+                </label>
+              </div>
+              <div class="col-xs-12 col-sm-8">
+                <input class="form-control" id="email" name="email" type="text" maxlength="200" required="required" value="{{org.email}}">
+              </div>
+            </div>
+            <br />
+            <br class="hidden-xs" />
+            
             <div class="text-center">
               <button type="submit" form="update-profile" value="Update" class="btn btn-primary">Save Changes</button>
             </div>


### PR DESCRIPTION
Login page updates:

- Move sign-up form, signed-in message to top of page
- Hide Google button after connecting to account. 
- Re-style sign-up form to match profile edit form.

Now, exactly one of these options should be visible for a given state: Google sign-in button, Voluntr sign-up form, Voluntr redirecting-to-homepage message. All of these appear at the same place in the view: below the Organization Sign-Up heading, and above the about-Voluntr material.