### PR TITLE
Add "Flexible Schedule" option to add/edit opp forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 0.36.8
+## Current Version: 0.37.0
 
 
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -73,6 +73,10 @@ p.help-block {
   margin-top: 20px;
 }
 
+.checkbox-opp-form {
+  margin-top: 3px;
+}
+
 /*Uses code from Bootstrap's btn-justified class, only on small screens:*/
 @media (max-width: 768px) {
   .opp-nav-buttons {

--- a/static/js/org.js
+++ b/static/js/org.js
@@ -32,6 +32,7 @@ function deleteCookie(name) {
 function toggleFlexible(e) {
   var scheduleInputs = document.querySelectorAll('.schedule-input');
   var scheduleLabels = document.querySelectorAll('.schedule-label');
+  var addressInput = document.getElementById('address');
 
   if(e.target.checked) {
 
@@ -43,6 +44,9 @@ function toggleFlexible(e) {
       input.removeAttribute("required");
       input.setAttribute("disabled", true);
     });
+
+    // Focus the address input
+    addressInput.focus();
   } else {
 
     // Reset labels and inputs to initial state

--- a/static/js/org.js
+++ b/static/js/org.js
@@ -26,6 +26,36 @@ function deleteCookie(name) {
   document.cookie = name +'=; Path=/; Expires=Thu, 01 Jan 1970 00:00:01 GMT;';
 }
 
+// ~~~~~~~~~~~~~~~~~Add/Edit Opp form~~~~~~~~~~~~~~~~~
+
+// Update form to require/not allow date and times, based on Flexible Schedule checkbox
+function toggleFlexible(e) {
+  var scheduleInputs = document.querySelectorAll('.schedule-input');
+  var scheduleLabels = document.querySelectorAll('.schedule-label');
+
+  if(e.target.checked) {
+
+    // Dim labels and inputs, stop requiring them, mark input disabled
+    scheduleLabels.forEach(function(label){
+      label.classList.add('text-muted');
+    });
+    scheduleInputs.forEach(function(input){
+      input.removeAttribute("required");
+      input.setAttribute("disabled", true);
+    });
+  } else {
+
+    // Reset labels and inputs to initial state
+    scheduleLabels.forEach(function(label){
+      label.classList.remove('text-muted');
+    });
+    scheduleInputs.forEach(function(input){
+      input.setAttribute("required", true);
+      input.removeAttribute("disabled");
+    });
+  }
+}
+
 
 // ~~~~~~~~~~~~~~~~User account authorization:~~~~~~~~~~~~~~~~~~~
 // Callback function for Google API's sign-in event
@@ -143,11 +173,16 @@ if (typeof window !== "undefined") {
 
     //when the sign-out link is clicked, the signOut function is executed
     var signOutLink = document.querySelectorAll(".signOutLink");
+    var flexibleCheckbox = document.getElementById("flexible");
 
     if (signOutLink) {
       signOutLink.forEach(function(link){
         link.addEventListener("click", signOut);
       });
+    }
+
+    if (flexibleCheckbox) {
+      flexibleCheckbox.addEventListener("click", toggleFlexible);
     }
     
   })();

--- a/templates/organization/add.html
+++ b/templates/organization/add.html
@@ -44,6 +44,24 @@
             <div class="row">
               <div class="col-xs-12 col-sm-4">
                 <label for="date">
+                  <h3>Flexible Schedule?</h3>
+                </label>
+              </div>
+              <div class="col-xs-12 col-sm-8">
+                <div class="checkbox">
+                  <label>
+                    <input id="flexible" name="flexible" type="checkbox" value="">
+                    Yes, please display "Flexible schedule" for this post instead of a specific date and time.
+                  </label>
+                </div>
+              </div>
+            </div>
+            <br />
+            <br class="hidden-xs" />
+
+            <div class="row">
+              <div class="col-xs-12 col-sm-4">
+                <label for="date">
                   <h3>Date</h3>
                 </label>
               </div>

--- a/templates/organization/add.html
+++ b/templates/organization/add.html
@@ -50,7 +50,7 @@
               <div class="col-xs-12 col-sm-8">
                 <div class="checkbox">
                   <label>
-                    <input id="flexible" name="flexible" type="checkbox" value="">
+                    <input id="flexible" name="flexible" type="checkbox" value="on">
                     Yes, please display "Flexible schedule" for this post instead of a specific date and time.
                   </label>
                 </div>

--- a/templates/organization/add.html
+++ b/templates/organization/add.html
@@ -48,7 +48,7 @@
                 </label>
               </div>
               <div class="col-xs-12 col-sm-8">
-                <div class="checkbox">
+                <div class="checkbox checkbox-opp-form">
                   <label>
                     <input id="flexible" name="flexible" type="checkbox" value="on">
                     Yes, please display "Flexible schedule" for this post instead of a specific date and time.

--- a/templates/organization/add.html
+++ b/templates/organization/add.html
@@ -61,12 +61,12 @@
 
             <div class="row">
               <div class="col-xs-12 col-sm-4">
-                <label for="date">
+                <label for="date" class="schedule-label">
                   <h3>Date</h3>
                 </label>
               </div>
               <div class="col-xs-12 col-sm-8">
-                <input class="form-control" id="date" name="date" type="date" required>
+                <input class="form-control schedule-input" id="date" name="date" type="date" required>
               </div>
             </div>
             <br />
@@ -74,12 +74,12 @@
 
             <div class="row">
               <div class="col-xs-12 col-sm-4">
-                <label for="startTime">
+                <label for="startTime" class="schedule-label">
                   <h3>Start Time</h3>
                 </label>
               </div>
               <div class="col-xs-12 col-sm-8">
-                <input class="form-control" id="startTime" type="time" name="startTime" value="12:00" required>
+                <input class="form-control schedule-input" id="startTime" type="time" name="startTime" value="12:00" required>
               </div>
             </div>
             <br />
@@ -87,12 +87,12 @@
 
             <div class="row">
               <div class="col-xs-12 col-sm-4">
-                <label for="endTime">
+                <label for="endTime" class="schedule-label">
                   <h3>End Time</h3>
                 </label>
               </div>
               <div class="col-xs-12 col-sm-8">
-                <input class="form-control" id="endTime" type="time" name="endTime" value="12:30" required>
+                <input class="form-control schedule-input" id="endTime" type="time" name="endTime" value="12:30" required>
               </div>
             </div>
             <br />

--- a/templates/organization/add.html
+++ b/templates/organization/add.html
@@ -57,7 +57,6 @@
               </div>
             </div>
             <br />
-            <br class="hidden-xs" />
 
             <div class="row">
               <div class="col-xs-12 col-sm-4">

--- a/templates/organization/edit.html
+++ b/templates/organization/edit.html
@@ -44,46 +44,126 @@
               </div>
             </div>
             <br />
-            <br class="hidden-xs" />
 
-            <div class="row">
-              <div class="col-xs-12 col-sm-4">
-                <label for="date">
-                  <h3>Date</h3>
-                </label>
+            {% if event_date == "2100-01-01" %}
+              <div class="row">
+                <div class="col-xs-12 col-sm-4">
+                  <label for="date">
+                    <h3>Flexible Schedule?</h3>
+                  </label>
+                </div>
+                <div class="col-xs-12 col-sm-8">
+                  <div class="checkbox checkbox-opp-form">
+                    <label>
+                      <input id="flexible" name="flexible" type="checkbox" value="on" checked>
+                      Yes, please display "Flexible schedule" for this post instead of a specific date and time.
+                    </label>
+                  </div>
+                </div>
               </div>
-              <div class="col-xs-12 col-sm-8">
-                <input class="form-control" id="date" name="date" type="date" required value="{{event_date}}">
-              </div>
-            </div>
-            <br />
-            <br class="hidden-xs" />
+              <br />
+              <br class="hidden-xs" />
 
-            <div class="row">
-              <div class="col-xs-12 col-sm-4">
-                <label for="startTime">
-                  <h3>Start Time</h3>
-                </label>
+              <div class="row">
+                <div class="col-xs-12 col-sm-4">
+                  <label for="date" class="schedule-label">
+                    <h3>Date</h3>
+                  </label>
+                </div>
+                <div class="col-xs-12 col-sm-8">
+                  <input class="form-control schedule-input" id="date" name="date" type="date" disabled>
+                </div>
               </div>
-              <div class="col-xs-12 col-sm-8">
-                <input class="form-control" id="startTime" type="time" name="startTime" value="{{time_start}}" required>
-              </div>
-            </div>
-            <br />
-            <br class="hidden-xs" />
+              <br />
+              <br class="hidden-xs" />
 
-            <div class="row">
-              <div class="col-xs-12 col-sm-4">
-                <label for="endTime">
-                  <h3>End Time</h3>
-                </label>
+              <div class="row">
+                <div class="col-xs-12 col-sm-4">
+                  <label for="startTime" class="schedule-label">
+                    <h3>Start Time</h3>
+                  </label>
+                </div>
+                <div class="col-xs-12 col-sm-8">
+                  <input class="form-control schedule-input" id="startTime" type="time" name="startTime" disabled>
+                </div>
               </div>
-              <div class="col-xs-12 col-sm-8">
-                <input class="form-control" id="endTime" type="time" name="endTime" value="{{time_end}}" required>
+              <br />
+              <br class="hidden-xs" />
+
+              <div class="row">
+                <div class="col-xs-12 col-sm-4">
+                  <label for="endTime" class="schedule-label">
+                    <h3>End Time</h3>
+                  </label>
+                </div>
+                <div class="col-xs-12 col-sm-8">
+                  <input class="form-control schedule-input" id="endTime" type="time" name="endTime" disabled>
+                </div>
               </div>
-            </div>
-            <br />
-            <br class="hidden-xs" />
+              <br />
+              <br class="hidden-xs" />
+            {% endif %}
+
+            {% if event_date != "2100-01-01" %}
+              <div class="row">
+                <div class="col-xs-12 col-sm-4">
+                  <label for="date">
+                    <h3>Flexible Schedule?</h3>
+                  </label>
+                </div>
+                <div class="col-xs-12 col-sm-8">
+                  <div class="checkbox checkbox-opp-form">
+                    <label>
+                      <input id="flexible" name="flexible" type="checkbox" value="on">
+                      Yes, please display "Flexible schedule" for this post instead of a specific date and time.
+                    </label>
+                  </div>
+                </div>
+              </div>
+              <br />
+              <br class="hidden-xs" />
+
+              <div class="row">
+                <div class="col-xs-12 col-sm-4">
+                  <label for="date" class="schedule-label">
+                    <h3>Date</h3>
+                  </label>
+                </div>
+                <div class="col-xs-12 col-sm-8">
+                  <input class="form-control schedule-input" id="date" name="date" type="date" required value="{{event_date}}">
+                </div>
+              </div>
+              <br />
+              <br class="hidden-xs" />
+
+              <div class="row">
+                <div class="col-xs-12 col-sm-4">
+                  <label for="startTime" class="schedule-label">
+                    <h3>Start Time</h3>
+                  </label>
+                </div>
+                <div class="col-xs-12 col-sm-8">
+                  <input class="form-control schedule-input" id="startTime" type="time" name="startTime" value="{{time_start}}" required>
+                </div>
+              </div>
+              <br />
+              <br class="hidden-xs" />
+
+              <div class="row">
+                <div class="col-xs-12 col-sm-4">
+                  <label for="endTime" class="schedule-label">
+                    <h3>End Time</h3>
+                  </label>
+                </div>
+                <div class="col-xs-12 col-sm-8">
+                  <input class="form-control schedule-input" id="endTime" type="time" name="endTime" value="{{time_end}}" required>
+                </div>
+              </div>
+              <br />
+              <br class="hidden-xs" />
+            {% endif %}
+
+            
 
             <div class="row">
               <div class="col-xs-12 col-sm-4">

--- a/voluntr.py
+++ b/voluntr.py
@@ -187,9 +187,6 @@ def new_opportunity():
     if request.method == 'POST':
         # get all form data
         title = validate_title(request.form["title"])
-        date = request.form["date"]
-        start_time = request.form["startTime"]
-        end_time = request.form["endTime"]
         address = request.form["address"]
         city = request.form["city"]
         state = request.form["state"]
@@ -198,6 +195,16 @@ def new_opportunity():
         category = get_category(category_class)
         description = validate_description(request.form["description"])
         next_steps = validate_next_steps(request.form["nextsteps"])
+
+        # Either get the form's date/times, or add the date/times we've chosen to signify "flexible schedule"
+        if request.form.get("flexible"):
+            date = "2100-01-01"
+            start_time = "23:30"
+            end_time = "23:30"
+        else:
+            date = request.form["date"]
+            start_time = request.form["startTime"]
+            end_time = request.form["endTime"]
         
         # format dateStartTime
         start_date_time = create_datetime(date, start_time)

--- a/voluntr.py
+++ b/voluntr.py
@@ -282,10 +282,17 @@ def edit_opportunity():
         opp.zipcode = request.form["zipcode"]
         opp.description = validate_description(request.form["description"])
         
+        # Either get the form's date/times, or add the date/times we've chosen to signify "flexible schedule"
+        if request.form.get("flexible"):
+            date = "2100-01-01"
+            start_time = "23:30"
+            end_time = "23:30"
+        else:
+            date = request.form["date"]
+            start_time = request.form["startTime"]
+            end_time = request.form["endTime"]
+
         # format dateStartTime and duration
-        date = request.form["date"]
-        start_time = request.form["startTime"]
-        end_time = request.form["endTime"]
         opp.startDateTime = create_datetime(date, start_time)
         opp.duration = get_duration(start_time, end_time)
         


### PR DESCRIPTION
For both Add Opp and Edit Opp forms:
- Add "flexible schedule" checkbox.
- Upon choosing flexible schedule, dim/disable the inputs for date, start time, and end time, then move the browser's focus to the address field.
- Prep the controllers to accept the possibility of a flexible schedule. (We're still using the convention that 2017-01-01, 23:30 signifies a flexible schedule.)

Resolves issue #152 .