### PR TITLE
Adds "delete" option for orgs to remove opportunities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 0.37.0
+## Current Version: 0.38.0
 
 
 <b> A web app that provides a simple platform for nonprofits to connect with potential volunteers</b>
@@ -88,7 +88,7 @@ We are targetting both Nonprofit Organizations and potential volunteers.
 | --- | --- |--- |
 | register my organization on Voluntr | MVP | Passing :white_check_mark: |
 | easily submit open volunteer opportunities | MVP | Passing :white_check_mark: |
-| edit or remove a posted opportunity  | MVP  | Not Passing :red_circle: |
+| edit or remove a posted opportunity  | MVP  | Passing :white_check_mark: |
 | view the list of posted opportunities that are open  | MVP | Passing :white_check_mark: |
 | view and edit profile settings for my organization, including name, contact email, and any other profile data  | MVP | Passing :white_check_mark: |
 | log in to my existing account and logout when I'm done  | MVP | Passing :white_check_mark: |

--- a/filters.py
+++ b/filters.py
@@ -28,11 +28,11 @@ class Filters():
 
     def filter_by_categories(self):
         if self.categories[0] == "all" or len(self.categories) == len(get_categories()):
-            opps = Opportunity.query.all()
+            opps = Opportunity.query.filter_by(display = 1).all()
         else:
             opps = []
             for i in range(len(self.categories)):
-                opps = opps + Opportunity.query.filter_by(category_class=self.categories[i]).all()
+                opps = opps + Opportunity.query.filter_by(category_class=self.categories[i], display = 1).all()
 
         return opps
 

--- a/models/org.py
+++ b/models/org.py
@@ -34,6 +34,7 @@ class Opportunity(db.Model):
     category = db.Column(db.String(35))
     nextSteps = db.Column(db.String(1000))
     owner_id = db.Column(db.String(200), db.ForeignKey('organization.userid'))
+    display = db.Column(db.Boolean, unique = False, default=True)
 
     def __init__(self, title, address, city, state, zipcode, description, startDateTime, duration, category_class, category, nextSteps, owner):
         self.title = title
@@ -48,6 +49,7 @@ class Opportunity(db.Model):
         self.category = category
         self.nextSteps = nextSteps
         self.owner_id = owner
+        self.display = True
 
     def __repr__(self):
         return '<Opportunity %r>' % self.title

--- a/templates/organization/edit.html
+++ b/templates/organization/edit.html
@@ -276,7 +276,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">No, keep it</button>
-          <a class="btn btn-danger" href="./opportunities" role="button">Yes, delete it&nbsp;
+          <a class="btn btn-danger" href="./opportunities?del={{opp.id}}" role="button">Yes, delete it&nbsp;
             <div class="glyphicon glyphicon-remove-sign"></div>
           </a>
         </div>

--- a/templates/organization/preview.html
+++ b/templates/organization/preview.html
@@ -68,7 +68,7 @@
         </div>
         <div class="modal-footer">
           <button type="button" class="btn btn-default" data-dismiss="modal">No, keep it</button>
-          <a class="btn btn-danger" href="./opportunities" role="button">Yes, delete it&nbsp;
+          <a class="btn btn-danger" href="./opportunities?del={{opp.id}}" role="button">Yes, delete it&nbsp;
             <div class="glyphicon glyphicon-remove-sign"></div>
           </a>
         </div>

--- a/voluntr.py
+++ b/voluntr.py
@@ -170,7 +170,18 @@ def manage_opportunities():
 
         # define variables to pass into the template
         org_name = org.orgName
+
+        # check for deleted opportunities:
+        opp_id = request.args.get("del")
+        if opp_id:
+            hide_opp = get_opp_by_id(opp_id)
+            hide_opp.display = False
+            if validate_opp_data() == True:
+                db.session.commit()
+
+        # display all active opportunities on the org homepage
         opps = db.session.query(Opportunity).filter_by(owner_id = org.userid, display = 1).all()
+        
         # format datetime into more readable strings
         for opp in opps:
             opp.startDateTime = readable_date(opp.startDateTime)

--- a/voluntr.py
+++ b/voluntr.py
@@ -170,7 +170,7 @@ def manage_opportunities():
 
         # define variables to pass into the template
         org_name = org.orgName
-        opps = Opportunity.query.filter_by(owner_id = org.userid).all()
+        opps = db.session.query(Opportunity).filter_by(owner_id = org.userid, display = 1).all()
         # format datetime into more readable strings
         for opp in opps:
             opp.startDateTime = readable_date(opp.startDateTime)


### PR DESCRIPTION
Resolves #169 

Adds a column to the Opportunity model called "Display", set as a boolean.  
Adjusted filters and other views so that only opportunites with display = true are shown to the user, but the opportunity data remains in the db.  
Both delete buttons (org/opportunity and org/edit) reroute org to the homepage with a query parameter "del" - org/opportunities checks for this parameter and changes the display value for that opp to False, which removes it from all opportunity views.  

I also changed the user stories in the readme - looks like we have met all of our MVP goals!