### PR TITLE
disable static-asset cache, SQL_TRACK_MODIFICATIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Voluntr
 
-## Current Version: 1.0.1
+## Current Version: 1.0.2
 
 
 <h4> A web app that provides a simple platform for nonprofits to connect with potential volunteers. <br>

--- a/app.py
+++ b/app.py
@@ -12,7 +12,9 @@ app = Flask(__name__)
 app.config['DEBUG'] = True      # displays runtime errors in the browser, too
 app.config['SQLALCHEMY_DATABASE_URI'] = db_uri
 app.config['SQLALCHEMY_ECHO'] = True
-app.config['SQLALCHEMY_POOL_RECYCLE'] = 30
+app.config['SQLALCHEMY_POOL_RECYCLE'] = 30 # required to keep connections to ClearDB from failing
+app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0 # re-load static assets every time
 app.secret_key = 'ZAj08N/$3m]XHjHy!rX R/~?X,9RW@UL'
 
 db = SQLAlchemy(app)


### PR DESCRIPTION
- Should eliminate need to manually disable caching in the browser. Eventually, this setting should only apply to the development environment.
- Set `SQL_TRACK_MODIFICATIONS` setting to False, which suppresses a warning message in the console.